### PR TITLE
Improve dockerfile for gsad

### DIFF
--- a/.docker/main.Dockerfile
+++ b/.docker/main.Dockerfile
@@ -37,8 +37,15 @@ RUN apt-get update && \
 
 COPY --from=builder /install/ /
 
-# create web directory where GSA should be placed
-RUN mkdir -p /usr/local/share/gvm/gsad/web
+RUN addgroup --gid 1001 --system gsad && \
+    adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gsad
+
+# create web directory where GSA should be placed and runtime files directories
+RUN mkdir -p /usr/local/share/gvm/gsad/web && \
+    mkdir -p /run/gvm/gsad && \
+    chown -R gsad:gsad /run/gvm
+
+USER gsad
 
 ENTRYPOINT [ "gsad" ]
-CMD ["-f", "--http-only"]
+CMD ["-f", "--http-only", "--unix-socket=/run/gvm/gsad/gsad.sock", "--munix-socket=/run/gvmd/gvmd.sock", "--vendor-version='Community Container'"]


### PR DESCRIPTION
**What**:

Use a dedicated user for gsad, set unix socket locations on startup and
use a vendor version by default.

**Why**:

When starting the gsad container it should not run as root and the runtime directories should be separated (which is not possible completely yet).

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
