### PR TITLE
CHANGE: Use full path GSAD_PID_PATH for PID files, change GVM_RUN_DIR to GSAD_RUN_DIR, GVMD_RUN_DIR 

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -43,9 +43,9 @@ RUN addgroup --gid 1001 --system gsad && \
 
 # create web directory where GSA should be placed and runtime files directories
 RUN mkdir -p /usr/local/share/gvm/gsad/web && \
-    mkdir -p /run/gvm/gsad && \
+    mkdir -p /run/gsad && \
     mkdir -p /var/log/gvm && \
-    chown -R gsad:gsad /run/gvm && \
+    chown -R gsad:gsad /run/gsad && \
     chown -R gsad:gsad /var/log/gvm
 
 USER gsad

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,13 +85,17 @@ endif (NOT DATADIR)
 set (GSAD_DATA_DIR "${DATADIR}/gvm/gsad")
 set (GSAD_CONFIG_DIR "${SYSCONFDIR}/gvm/")
 
-if (NOT GVM_RUN_DIR)
-  set (GVM_RUN_DIR  "/run/gvm")
-endif (NOT GVM_RUN_DIR)
+if (NOT GSAD_RUN_DIR)
+  set (GSAD_RUN_DIR  "/run/gsad")
+endif (NOT GSAD_RUN_DIR)
 
 if (NOT GSAD_PID_PATH)
-  set (GSAD_PID_PATH     "/run/gsad/gsad.pid")
+  set (GSAD_PID_PATH     "${GSAD_RUN_DIR}/gsad.pid")
 endif (NOT GSAD_PID_PATH)
+
+if (NOT GVMD_RUN_DIR)
+  set (GVMD_RUN_DIR  "/run/gvmd")
+endif (NOT GVMD_RUN_DIR)
 
 if (NOT GSAD_PID_DIR)
   set (GSAD_PID_DIR "${GVM_RUN_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,8 @@ configure_file (src/gsad_log_conf.cmake_in src/gsad_log.conf)
 
 ## Install
 
+install (DIRECTORY DESTINATION ${GSAD_RUN_DIR})
+
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/src/gsad_log.conf
          DESTINATION ${GSAD_CONFIG_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,10 @@ if (NOT GVM_RUN_DIR)
   set (GVM_RUN_DIR  "/run/gvm")
 endif (NOT GVM_RUN_DIR)
 
+if (NOT GSAD_PID_PATH)
+  set (GSAD_PID_PATH     "/run/gsad/gsad.pid")
+endif (NOT GSAD_PID_PATH)
+
 if (NOT GSAD_PID_DIR)
   set (GSAD_PID_DIR "${GVM_RUN_DIR}")
 endif (NOT GSAD_PID_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,12 +125,16 @@ if (GVM_CA_CERTIFICATE)
   add_definitions (-DGVM_CA_CERTIFICATE="${GVM_CA_CERTIFICATE}")
 endif (GVM_CA_CERTIFICATE)
 
-if (GVM_RUN_DIR)
-  add_definitions (-DGVM_RUN_DIR="${GVM_RUN_DIR}")
-endif (GVM_RUN_DIR)
+if (GVMD_RUN_DIR)
+  add_definitions (-DGVMD_RUN_DIR="${GVMD_RUN_DIR}")
+endif (GVMD_RUN_DIR)
+
+if (GSAD_RUN_DIR)
+  add_definitions (-DGSAD_RUN_DIR="${GSAD_RUN_DIR}")
+endif (GSAD_RUN_DIR)
 
 if (GSAD_PID_PATH)
-        add_definitions (-DGSAD_PID_PATH="${GSAD_PID_PATH}")
+  add_definitions (-DGSAD_PID_PATH="${GSAD_PID_PATH}")
 endif (GSAD_PID_PATH)
 
 if (GSAD_DATA_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,10 @@ if (GVM_RUN_DIR)
   add_definitions (-DGVM_RUN_DIR="${GVM_RUN_DIR}")
 endif (GVM_RUN_DIR)
 
+if (GSAD_PID_PATH)
+        add_definitions (-DGSAD_PID_PATH="${GSAD_PID_PATH}")
+endif (GSAD_PID_PATH)
+
 if (GSAD_DATA_DIR)
   add_definitions (-DGSAD_DATA_DIR="${GSAD_DATA_DIR}")
 endif (GSAD_DATA_DIR)

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -2483,7 +2483,7 @@ gsad_cleanup ()
 
   gsad_base_cleanup ();
 
-  pidfile_remove ("gsad");
+  pidfile_remove (GSAD_PID_PATH);
 }
 
 /**
@@ -3155,7 +3155,7 @@ main (int argc, char **argv)
 
   /* Write pidfile. */
 
-  if (pidfile_create ("gsad"))
+  if (pidfile_create (GSAD_PID_PATH))
     {
       g_critical ("%s: Could not write PID file.\n", __func__);
       exit (EXIT_FAILURE);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -284,7 +284,7 @@ gmp_init (const gchar *manager_address_unix, const gchar *manager_address_tls,
     }
   else
     {
-      manager_address = g_build_filename (GVM_RUN_DIR, "gvmd.sock", NULL);
+      manager_address = g_build_filename (GVMD_RUN_DIR, "gvmd.sock", NULL);
       manager_use_tls = 0;
     }
   manager_port = port_manager;


### PR DESCRIPTION
**What**:
The calls of pidfile_create and pidfile_remove are adjusted to use a
full path defined by GSAD_PID_PATH.

The new path GSAD_RUN_DIR is specific to gsad and GVMD_RUN_DIR only
has to be shared with gvmd and other modules using GMP via file socket.

**Why**:
To make gsad work correctly with the changes in greenbone/gvm-libs/pull/626 (AP-1789)

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
