### PR TITLE
Improve container

### DIFF
--- a/.docker/gsad_log.conf
+++ b/.docker/gsad_log.conf
@@ -1,0 +1,27 @@
+[gsad main]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/gsad.log
+level=127
+
+[gsad  gmp]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/gsad.log
+level=127
+
+[gsad http]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/gsad.log
+level=127
+
+[*]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/gsad.log
+level=16

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -44,7 +44,9 @@ RUN addgroup --gid 1001 --system gsad && \
 # create web directory where GSA should be placed and runtime files directories
 RUN mkdir -p /usr/local/share/gvm/gsad/web && \
     mkdir -p /run/gvm/gsad && \
-    chown -R gsad:gsad /run/gvm
+    mkdir -p /var/log/gvm && \
+    chown -R gsad:gsad /run/gvm && \
+    chown -R gsad:gsad /var/log/gvm
 
 USER gsad
 

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install/ /
+COPY .docker/gsad_log.conf /etc/gvm/
 
 RUN addgroup --gid 1001 --system gsad && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gsad

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -51,4 +51,4 @@ RUN mkdir -p /usr/local/share/gvm/gsad/web && \
 USER gsad
 
 ENTRYPOINT [ "gsad" ]
-CMD ["-f", "--http-only", "--unix-socket=/run/gvm/gsad/gsad.sock", "--munix-socket=/run/gvmd/gvmd.sock", "--vendor-version='Community Container'"]
+CMD ["-f", "--http-only", "--vendor-version='Community Container'"]


### PR DESCRIPTION
**What**:

Configure logging and use sane defaults for unix sockets.

**Why**:

Getting logging output is necessary for debugging gsad issues and using /run/gvm/gsad for the gsad unix socket location via mounting a docker volume doesn't work for unknown reasons.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
