### PR TITLE
Add status 503 case to set_http_status_from_entity

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -536,6 +536,9 @@ set_http_status_from_entity (entity_t entity,
     cmd_response_data_set_status_code (response_data, MHD_HTTP_FORBIDDEN);
   else if (str_equal (entity_attribute (entity, "status"), "404"))
     cmd_response_data_set_status_code (response_data, MHD_HTTP_NOT_FOUND);
+  else if (str_equal (entity_attribute (entity, "status"), "503"))
+    cmd_response_data_set_status_code (response_data,
+                                       MHD_HTTP_SERVICE_UNAVAILABLE);
   else
     cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
 }


### PR DESCRIPTION
**What**:
If a GMP response contains status 503 (Service Unavailable), gsad will
now also use 503 as the HTTP response code.

**Why**:
To differentiate these errors from other errors like invalid requests.
AP-1570

**How**:
Requested the license page when gvmd was built with licensing enabled
but the theia service was not running and checked the HTTP status in the
browser dev tools.

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
