### PR TITLE
Improve gsad container start

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
 
 COPY --from=builder /install/ /
 COPY .docker/gsad_log.conf /etc/gvm/
+COPY .docker/start-gsad.sh /usr/local/bin/start-gsad
 
 RUN addgroup --gid 1001 --system gsad && \
     adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gsad
@@ -46,9 +47,9 @@ RUN mkdir -p /usr/local/share/gvm/gsad/web && \
     mkdir -p /run/gsad && \
     mkdir -p /var/log/gvm && \
     chown -R gsad:gsad /run/gsad && \
-    chown -R gsad:gsad /var/log/gvm
+    chown -R gsad:gsad /var/log/gvm && \
+    chmod 755 /usr/local/bin/start-gsad
 
 USER gsad
 
-ENTRYPOINT [ "gsad" ]
-CMD ["-f", "--http-only", "--vendor-version='Community Container'"]
+CMD ["/usr/local/bin/start-gsad"]

--- a/.docker/start-gsad.sh
+++ b/.docker/start-gsad.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+[ -z "$GSAD_ARGS" ] && GSAD_ARGS="-f --http-only"
+
+echo "starting gsad"
+gsad $GSAD_ARGS ||
+	(cat /var/log/gvm/gsad.log && exit 1)
+
+tail -f /var/log/gvm/gsad.log


### PR DESCRIPTION
**What**:

Add an extensible start script for gsad to the container image.

**Why**:

Allow for easier adjusting the start parameters of gsad while always displaying the log output.

**How**:

Tested the container locally.

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
