### PR TITLE
Changed the order of the parameters of MHD_start_daemon (...)

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -2640,11 +2640,10 @@ start_unix_http_daemon (const char *unix_socket_path,
   return MHD_start_daemon (
     MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
       | MHD_USE_DEBUG,
-    0, NULL, NULL, handler, http_handlers,
-    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_NOTIFY_COMPLETED,
-    free_resources, NULL, MHD_OPTION_LISTEN_SOCKET, unix_socket,
-    MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
-    MHD_OPTION_END);
+    0, NULL, NULL, handler, http_handlers, MHD_OPTION_EXTERNAL_LOGGER,
+    mhd_logger, NULL, MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL,
+    MHD_OPTION_LISTEN_SOCKET, unix_socket, MHD_OPTION_PER_IP_CONNECTION_LIMIT,
+    get_per_ip_connection_limit (), MHD_OPTION_END);
 }
 
 static struct MHD_Daemon *
@@ -2682,11 +2681,10 @@ start_http_daemon (int port,
 #endif
 
   return MHD_start_daemon (
-    flags, port, NULL, NULL, handler, http_handlers,
-    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL,
-    MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL, MHD_OPTION_SOCK_ADDR,
-    address, MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
-    MHD_OPTION_END);
+    flags, port, NULL, NULL, handler, http_handlers, MHD_OPTION_EXTERNAL_LOGGER,
+    mhd_logger, NULL, MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL,
+    MHD_OPTION_SOCK_ADDR, address, MHD_OPTION_PER_IP_CONNECTION_LIMIT,
+    get_per_ip_connection_limit (), MHD_OPTION_END);
 }
 
 static struct MHD_Daemon *
@@ -2716,10 +2714,10 @@ start_https_daemon (int port, const char *key, const char *cert,
 
   return MHD_start_daemon (
     flags, port, NULL, NULL, &handle_request, http_handlers,
-    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL,
-    MHD_OPTION_HTTPS_MEM_KEY, key, MHD_OPTION_HTTPS_MEM_CERT, cert,
-    MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL, MHD_OPTION_SOCK_ADDR,
-    address, MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
+    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_HTTPS_MEM_KEY, key,
+    MHD_OPTION_HTTPS_MEM_CERT, cert, MHD_OPTION_NOTIFY_COMPLETED,
+    free_resources, NULL, MHD_OPTION_SOCK_ADDR, address,
+    MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
     MHD_OPTION_HTTPS_PRIORITIES, priorities,
 /* LibmicroHTTPD 0.9.35 and higher. */
 #if MHD_VERSION >= 0x00093500

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -2640,10 +2640,11 @@ start_unix_http_daemon (const char *unix_socket_path,
   return MHD_start_daemon (
     MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
       | MHD_USE_DEBUG,
-    0, NULL, NULL, handler, http_handlers, MHD_OPTION_NOTIFY_COMPLETED,
+    0, NULL, NULL, handler, http_handlers,
+    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_NOTIFY_COMPLETED,
     free_resources, NULL, MHD_OPTION_LISTEN_SOCKET, unix_socket,
     MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
-    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_END);
+    MHD_OPTION_END);
 }
 
 static struct MHD_Daemon *
@@ -2682,9 +2683,10 @@ start_http_daemon (int port,
 
   return MHD_start_daemon (
     flags, port, NULL, NULL, handler, http_handlers,
+    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL,
     MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL, MHD_OPTION_SOCK_ADDR,
     address, MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
-    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_END);
+    MHD_OPTION_END);
 }
 
 static struct MHD_Daemon *
@@ -2714,11 +2716,11 @@ start_https_daemon (int port, const char *key, const char *cert,
 
   return MHD_start_daemon (
     flags, port, NULL, NULL, &handle_request, http_handlers,
+    MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL,
     MHD_OPTION_HTTPS_MEM_KEY, key, MHD_OPTION_HTTPS_MEM_CERT, cert,
     MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL, MHD_OPTION_SOCK_ADDR,
     address, MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
-    MHD_OPTION_HTTPS_PRIORITIES, priorities, MHD_OPTION_EXTERNAL_LOGGER,
-    mhd_logger, NULL,
+    MHD_OPTION_HTTPS_PRIORITIES, priorities,
 /* LibmicroHTTPD 0.9.35 and higher. */
 #if MHD_VERSION >= 0x00093500
     dh_params ? MHD_OPTION_HTTPS_MEM_DHPARAMS : MHD_OPTION_END, dh_params,


### PR DESCRIPTION

**What**:
The order of the parameters of the function MHD_start_daemon (...)
was changed to get rid of warning messages.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is a bug-fix.
Addresses AP-1929. 
<!-- Why are these changes necessary? -->

**How**:
Started gsad several times and checked the log messages.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
