### PR TITLE
[CMake] Do not install run(-time) dir(ectory)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,6 @@ configure_file (src/gsad_log_conf.cmake_in src/gsad_log.conf)
 
 ## Install
 
-install (DIRECTORY DESTINATION ${GSAD_RUN_DIR})
-
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/src/gsad_log.conf
          DESTINATION ${GSAD_CONFIG_DIR})
 


### PR DESCRIPTION
Installing the empty GSAD_RUN_DIR serves no purpose. The run(-time)
directories of services should be dynamically created and not
statically installed. And gsad's systemd service file ensures that the
PIDFile is created, which is the only content of gsad's run
directory. And even if there would be further content, then systemd's
RuntimeDirectory directive should be used instead (as it is already
done for gvmd).

The bottom line is: in no case should run-time directories be
installed, they are to be created at *run-time*.