### PR TITLE
[gsad.service] Drop Group= directive

### DIFF
--- a/config/gsad.service.in
+++ b/config/gsad.service.in
@@ -7,7 +7,6 @@ Wants=gvmd.service
 [Service]
 Type=forking
 User=gvm
-Group=gvm
 PIDFile=${GSAD_PID_PATH}
 ExecStart=${SBINDIR}/gsad --listen 127.0.0.1 --port 9392 --http-only
 Restart=always


### PR DESCRIPTION
Specifying the Group is typically never required, as systemd's default
behavior to use the user's primary group is what you want anyways. And
to make the service file more readable, unnecessary directives should
be removed. So this removes the Group= directive.