### PR TITLE
[gasd.service] Add RuntimeDirectory=gsad

### DIFF
--- a/config/gsad.service.in
+++ b/config/gsad.service.in
@@ -8,6 +8,7 @@ Wants=gvmd.service
 Type=forking
 User=gvm
 PIDFile=${GSAD_PID_PATH}
+RuntimeDirectory=gsad
 ExecStart=${SBINDIR}/gsad --listen 127.0.0.1 --port 9392 --http-only
 Restart=always
 TimeoutStopSec=10


### PR DESCRIPTION
Just like the other Greenbone Vulnerability Assistant daemons, e.g.,
gvmd, when run under systemd, gsad needs to instruct systemd to create
the runtime directory /run/gsad (assuming $GSAD_PID_PATH is the
default of /run/gsad/gsad.pid).