### PR TITLE
Change service start up type from forking to exec

### DIFF
--- a/config/gsad.service.in
+++ b/config/gsad.service.in
@@ -5,12 +5,12 @@ After=network.target gvmd.service
 Wants=gvmd.service
 
 [Service]
-Type=forking
+Type=exec
 User=gvm
 PIDFile=${GSAD_PID_PATH}
 RuntimeDirectory=gsad
 RuntimeDirectoryMode=2775
-ExecStart=${SBINDIR}/gsad --listen 127.0.0.1 --port 9392 --http-only
+ExecStart=${SBINDIR}/gsad --foreground --listen 127.0.0.1 --port 9392 --http-only
 Restart=always
 TimeoutStopSec=10
 


### PR DESCRIPTION
`Type=forking` leads to problems (eg: https://forum.greenbone.net/t/gsad-service-activating/12993/13) and is unnecessary since gsad has a `--foreground` option.

**What**:

Switch gsad.service unit file from `Type=forking` to `Type=exec`

**Why**:

systemd appears to lose track of the gsad process when using `Type=forking` and become unable to stop the service, which then prevents the service from being later restarted (because it was never actually stopped).

**How**:

I've been running this configuration across multiple systems for a while, and

1. it solves the service shutdown/startup problems
2. it doesn't appear to cause any new problems

**Checklist**:

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry N/A
- [ ] Labels for ports to other branches N/A
