### PR TITLE
Fix: Fix regex for new glib2.0 >= 2.73.2

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -478,7 +478,7 @@ init_validator ()
   gvm_validator_add (validator, "asset_name", "(?s)^.*$");
   gvm_validator_add (validator, "asset_type", "^(host|os)$");
   gvm_validator_add (validator, "asset_id",
-                     "^([[:alnum:]-_.:\\/~()']|&amp;)+$");
+                     "^([[:alnum:]\\-_.:\\/~()']|&amp;)+$");
   gvm_validator_add (validator, "auth_algorithm", "^(md5|sha1)$");
   gvm_validator_add (validator, "auth_method", "^(0|1|2)$");
   /* Defined in RFC 2253. */
@@ -595,7 +595,7 @@ init_validator ()
   gvm_validator_add (validator, "list_fname",
                      "^([[:alnum:]_-]|%[%CcDFMmNTtUu])+$");
   /* Used for users, credentials, and scanner login name. */
-  gvm_validator_add (validator, "login", "^[[:alnum:]-_@.]+$");
+  gvm_validator_add (validator, "login", "^[[:alnum:]\\-_@.]+$");
   gvm_validator_add (validator, "lsc_password", "^.*$");
   gvm_validator_add (validator, "max_result", "^[0-9]+$");
   gvm_validator_add (validator, "max_groups", "^-?[0-9]+$");
@@ -605,10 +605,10 @@ init_validator ()
   gvm_validator_add (validator, "note_required", "(?s)^(.)+$");
   gvm_validator_add (validator, "note_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "override_id", "^[a-z0-9\\-]+$");
-  gvm_validator_add (validator, "name", "^[#-_[:alnum:], \\./]*$");
+  gvm_validator_add (validator, "name", "^[#\\-_[:alnum:], \\./]*$");
   gvm_validator_add (validator, "info_name", "(?s)^.*$");
   gvm_validator_add (validator, "info_type", "(?s)^.*$");
-  gvm_validator_add (validator, "info_id", "^([[:alnum:]-_.:\\/~()']|&amp;)+$");
+  gvm_validator_add (validator, "info_id", "^([[:alnum:]\\-_.:\\/~()']|&amp;)+$");
   gvm_validator_add (validator, "details", "^[0-1]$");
   /* Number is special cased in params_mhd_validate to remove the space. */
   gvm_validator_add (validator, "number", "^ *[0-9]+ *$");
@@ -660,7 +660,7 @@ init_validator ()
     "filter|group|host|info|nvt|note|os|ovaldef|override|permission|port_list|"
     "report|report_format|result|role|scanner|schedule|tag|target|task|ticket|"
     "tls_certificate|user|vuln|)$");
-  gvm_validator_add (validator, "resource_id", "^[[:alnum:]-_.:\\/~]*$");
+  gvm_validator_add (validator, "resource_id", "^[[:alnum:]\\-_.:\\/~]*$");
   gvm_validator_add (validator, "resources_action", "^(|add|set|remove)$");
   gvm_validator_add (
     validator, "optional_resource_type",
@@ -721,7 +721,7 @@ init_validator ()
   gvm_validator_add (validator, "uuid", "^[0-9abcdefABCDEF\\-]{1,40}$");
   gvm_validator_add (validator, "usage_type", "^(audit|policy|scan|)$");
   /* This must be "login" with space and comma. */
-  gvm_validator_add (validator, "users", "^[[:alnum:]-_@., ]*$");
+  gvm_validator_add (validator, "users", "^[[:alnum:]\\-_@., ]*$");
   gvm_validator_add (validator, "x_field", "^[\\[\\]_[:alnum:]]+$");
   gvm_validator_add (validator, "y_fields:name", "^[0-9]+$");
   gvm_validator_add (validator, "y_fields:value", "^[\\[\\]_[:alnum:]]+$");

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -608,7 +608,8 @@ init_validator ()
   gvm_validator_add (validator, "name", "^[#\\-_[:alnum:], \\./]*$");
   gvm_validator_add (validator, "info_name", "(?s)^.*$");
   gvm_validator_add (validator, "info_type", "(?s)^.*$");
-  gvm_validator_add (validator, "info_id", "^([[:alnum:]\\-_.:\\/~()']|&amp;)+$");
+  gvm_validator_add (validator, "info_id",
+                     "^([[:alnum:]\\-_.:\\/~()']|&amp;)+$");
   gvm_validator_add (validator, "details", "^[0-1]$");
   /* Number is special cased in params_mhd_validate to remove the space. */
   gvm_validator_add (validator, "number", "^ *[0-9]+ *$");


### PR DESCRIPTION
**What**:

Ensure our used regular expressions are pcre 2 compatible to fix support of glib2.0 >= 2.73.2

DEVOPS-426

Fixes #86

**Why**:

glib changed their internal regexp library to use pcre 2 in a minor release (!) with version 2.73.2. This breaks some of our regular expressions.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
