### PR TITLE
Fix: Allow brackets and en dash Unicode character in name and comment fields

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -499,7 +499,7 @@ init_validator ()
   gvm_validator_add (validator, "setting_value", "^.*$");
   gvm_validator_add (validator, "setting_name", "^.*$");
   gvm_validator_add (validator, "comment",
-                     "^[-_;':()@[:alnum:]äüöÄÜÖß, \\./]*$");
+                     "^[-–_;':()@[:alnum:]äüöÄÜÖß, \\./]*$");
   gvm_validator_add (validator, "config_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "condition", "^[[:alnum:] ]*$");
   gvm_validator_add (validator, "credential_id", "^[a-z0-9\\-]+$");
@@ -605,7 +605,7 @@ init_validator ()
   gvm_validator_add (validator, "note_required", "(?s)^(.)+$");
   gvm_validator_add (validator, "note_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "override_id", "^[a-z0-9\\-]+$");
-  gvm_validator_add (validator, "name", "^[#\\-_[:alnum:], \\./]*$");
+  gvm_validator_add (validator, "name", "^[#\\-–_[:alnum:], \\./()]*$");
   gvm_validator_add (validator, "info_name", "(?s)^.*$");
   gvm_validator_add (validator, "info_type", "(?s)^.*$");
   gvm_validator_add (validator, "info_id",


### PR DESCRIPTION
**What**:

Allow users to add curved brackets for name fields like target name. This seems to have worked before the pcre2 adjustments.

Additionally allow the en dash Unicode character (U+2013) for name and comment fields.

Closes #89

DEVOPS-475

**Why**:

All three characters seem to have worked before. Thus this PR is fixing a regression.

**How**:

Build a new GSA docker container with changed regrexps and tried to create a target including the new characters.
