### PR TITLE
Add: Add libcgreen1-dev package to build container

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && \
     libgnutls28-dev \
     libxml2-dev \
     libssh-gcrypt-dev \
-    libmicrohttpd-dev && \
+    libmicrohttpd-dev \
+    libcgreen1-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ldconfig


### PR DESCRIPTION
**What**:

Add libcgreen1-dev package to the build container image. cgreen is a library for C based unit tests.

**Why**:

The library is necessary to build and run the new unit tests.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
