### PR TITLE
Avoid cross origin forgery by using same-site cookie

### DIFF
--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -515,9 +515,9 @@ remove_sid (http_response_t *response)
    * Tim Brown's suggested cookie included a domain attribute.  How would
    * we get the domain in here?  Maybe a --domain option. */
 
-  value =
-    g_strdup_printf (SID_COOKIE_NAME "=0; expires=%s; path=/; %sHTTPonly",
-                     expires, (is_use_secure_cookie () ? "secure; " : ""));
+  value = g_strdup_printf (
+    SID_COOKIE_NAME "=0; expires=%s; path=/; %sHTTPonly; SameSite=strict",
+    expires, (is_use_secure_cookie () ? "secure; " : ""));
   ret = MHD_add_response_header (response, "Set-Cookie", value);
   g_free (value);
   return ret;
@@ -591,8 +591,9 @@ attach_sid (http_response_t *response, const char *sid)
    * we get the domain in here?  Maybe a --domain option. */
 
   value = g_strdup_printf (
-    SID_COOKIE_NAME "=%s; expires=%s; max-age=%d; path=/; %sHTTPonly", sid,
-    expires, timeout, (is_use_secure_cookie () ? "secure; " : ""));
+    SID_COOKIE_NAME
+    "=%s; expires=%s; max-age=%d; path=/; %sHTTPonly; SameSite=strict",
+    sid, expires, timeout, (is_use_secure_cookie () ? "secure; " : ""));
   ret = MHD_add_response_header (response, "Set-Cookie", value);
   g_free (value);
   return ret;


### PR DESCRIPTION
**What**:
Only allow access to the session cookie from the same site and not for third parties. This avoids CSRF attacks like like e.g. [BREACH](http://breachattack.com/).

For more details please take a look at
http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/

**Why**:
This fix was missing in the main and stable branches after moving gsad from the gsa repository to its own.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry N/A
- [x] Labels for ports to other branches
