### PR TITLE
Allow smb_max_protocol in alert method data

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -4460,6 +4460,7 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
             || (strcmp (method, "SMB") == 0
                 && (strcmp (name, "smb_credential") == 0
                     || strcmp (name, "smb_file_path") == 0
+                    || strcmp (name, "smb_max_protocol") == 0
                     || strcmp (name, "smb_report_format") == 0
                     || strcmp (name, "smb_share_path") == 0))
             || (strcmp (method, "SNMP") == 0


### PR DESCRIPTION
## What
The alert method data now can also contain the smb_max_protocol option.

## Why
To allow setting the option if the SMB server only supports older versions.

## References
GEA-38

## Checklist


