### PR TITLE
Use MHD_HTTP_UNPROCESSABLE_CONTENT for 9.74 or later

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -94,7 +94,11 @@
  * @brief HTTP status code for expected failure of gmp requests e.g. if some
  *        parameter was missing or invalid.
  */
+#if MHD_VERSION < 0x00097400
 #define GSAD_STATUS_INVALID_REQUEST MHD_HTTP_UNPROCESSABLE_ENTITY
+#else
+#define GSAD_STATUS_INVALID_REQUEST MHD_HTTP_UNPROCESSABLE_CONTENT
+#endif
 
 /**
  * @brief Initial filtered results per page on the report summary.


### PR DESCRIPTION
## What

Use MHD_HTTP_UNPROCESSABLE_CONTENT instead of deprecated MHD_HTTP_UNPROCESSABLE_ENTITY for libmicrohttpd 9.74 and later.

## Why

Gets build working when CMAKE_BUILD_TYPE is DEBUG.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

Was deprecated [in this commit](https://github.com/Karlson2k/libmicrohttpd/commit/8c644fc1f4d498ea489add8d40a68f5d3e5899fa).

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


