### PR TITLE
Add option to force LDAPS for authentication

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -14752,10 +14752,16 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (method, "Save Authentication");
   if (!strcmp (method, "method:ldap_connect"))
     {
-      const char *ldaphost, *authdn, *certificate;
+      const char *ldaphost, *authdn, *certificate, *ldaps_only;
       ldaphost = params_value (params, "ldaphost");
       authdn = params_value (params, "authdn");
       certificate = params_value (params, "certificate");
+
+      if (params_value (params, "ldaps_only")
+          && (strcmp (params_value (params, "ldaps_only"), "1") == 0))
+        ldaps_only = "true";
+      else
+        ldaps_only = "false";
 
       CHECK_VARIABLE_INVALID (ldaphost, "Save Authentication");
       CHECK_VARIABLE_INVALID (authdn, "Save Authentication");
@@ -14769,9 +14775,11 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
                   "<group name=\"%s\">" AUTH_CONF_SETTING ("enable", "%s")
                     AUTH_CONF_SETTING ("ldaphost", "%s")
                       AUTH_CONF_SETTING ("authdn", "%s")
-                        AUTH_CONF_SETTING ("cacert", "%s") "</group>"
-                                                           "</modify_auth>",
-                  method, truefalse, ldaphost, authdn, certificate);
+                        AUTH_CONF_SETTING ("ldaps-only", "%s")
+                          AUTH_CONF_SETTING ("cacert", "%s") "</group>"
+                                                             "</modify_auth>",
+                  method, truefalse, ldaphost, authdn, ldaps_only,
+                  certificate);
         }
       else
         /** @warning authdn shall contain a single %s, handle with care. */
@@ -14779,9 +14787,10 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
                     "<modify_auth>"
                     "<group name=\"%s\">" AUTH_CONF_SETTING ("enable", "%s")
                       AUTH_CONF_SETTING ("ldaphost", "%s")
-                        AUTH_CONF_SETTING ("authdn", "%s") "</group>"
-                                                           "</modify_auth>",
-                    method, truefalse, ldaphost, authdn);
+                        AUTH_CONF_SETTING ("authdn", "%s")
+                          AUTH_CONF_SETTING ("ldaps-only", "%s") "</group>"
+                                                                   "</modify_auth>",
+                    method, truefalse, ldaphost, authdn, ldaps_only);
     }
   else if (!strcmp (method, "method:radius_connect"))
     {

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -14778,19 +14778,19 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
                         AUTH_CONF_SETTING ("ldaps-only", "%s")
                           AUTH_CONF_SETTING ("cacert", "%s") "</group>"
                                                              "</modify_auth>",
-                  method, truefalse, ldaphost, authdn, ldaps_only,
-                  certificate);
+                  method, truefalse, ldaphost, authdn, ldaps_only, certificate);
         }
       else
         /** @warning authdn shall contain a single %s, handle with care. */
-        ret = gmpf (connection, credentials, &response, &entity, response_data,
-                    "<modify_auth>"
-                    "<group name=\"%s\">" AUTH_CONF_SETTING ("enable", "%s")
-                      AUTH_CONF_SETTING ("ldaphost", "%s")
-                        AUTH_CONF_SETTING ("authdn", "%s")
-                          AUTH_CONF_SETTING ("ldaps-only", "%s") "</group>"
-                                                                   "</modify_auth>",
-                    method, truefalse, ldaphost, authdn, ldaps_only);
+        ret =
+          gmpf (connection, credentials, &response, &entity, response_data,
+                "<modify_auth>"
+                "<group name=\"%s\">" AUTH_CONF_SETTING ("enable", "%s")
+                  AUTH_CONF_SETTING ("ldaphost", "%s")
+                    AUTH_CONF_SETTING ("authdn", "%s")
+                      AUTH_CONF_SETTING ("ldaps-only", "%s") "</group>"
+                                                             "</modify_auth>",
+                method, truefalse, ldaphost, authdn, ldaps_only);
     }
   else if (!strcmp (method, "method:radius_connect"))
     {

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -594,6 +594,7 @@ init_validator ()
   gvm_validator_alias (validator, "method", "condition");
   gvm_validator_alias (validator, "modify_password", "number");
   gvm_validator_alias (validator, "ldaphost", "hostport");
+  gvm_validator_alias (validator, "ldaps_only", "boolean");
   gvm_validator_alias (validator, "lean", "boolean");
   gvm_validator_alias (validator, "level_high", "boolean");
   gvm_validator_alias (validator, "level_medium", "boolean");


### PR DESCRIPTION
## What
This adds an extra authentication option to force LDAPS for LDAP authentication

## Why
The normal LDAP port may be blocked by a firewall, in which case only the LDAPS port should be tried.

## References
GEA-82
requires greenbone/gvm-libs/pull/747 and greenbone/gvmd/pull/1928 to work properly