### PR TITLE
Add section to log conf for validator

### DIFF
--- a/src/gsad_log_conf.cmake_in
+++ b/src/gsad_log_conf.cmake_in
@@ -31,6 +31,13 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gsad.log
 level=127
 
+[gsad vali]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/gsad.log
+level=127
+
 [*]
 prepend=%t %s %p
 separator=:


### PR DESCRIPTION
## What

New section in log configuration for G_LOG_DOMAIN "gsad vali".  Covers logs from file src/validator.c.

## Why

Handy to skip some logs when enabling others.
