### PR TITLE
Change: Skip CERT refs in get_config_family

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -6966,6 +6966,7 @@ get_config_family (gvm_connection_t *connection, credentials_t *credentials,
         "<get_nvts"
         " config_id=\"%s\" details=\"1\""
         " family=\"%s\" timeout=\"1\" preference_count=\"1\""
+        " skip_cert_refs=\"1\""
         " sort_field=\"%s\" sort_order=\"%s\"/>",
         config_id, family, sort_field ? sort_field : "nvts.name",
         sort_order ? sort_order : "ascending")
@@ -7008,6 +7009,7 @@ get_config_family (gvm_connection_t *connection, credentials_t *credentials,
                                 " family=\"%s\""
                                 " preferences_config_id=\"%s\""
                                 " preference_count=\"1\""
+                                " skip_cert_refs=\"1\""
                                 " sort_field=\"%s\""
                                 " sort_order=\"%s\"/>",
                                 family, config_id,


### PR DESCRIPTION
## What

Use the new GET_NVTS skip_cert_refs flag to speed up get_config_family.

With greenbone/gvmd/pull/2009 the Edit dialog for config family Databases opens in about 10s.  With this PR it opens in about 5s.

## Why

The Edit Config Family dialog opens too slowly.

## References

Requires greenbone/gvmd/pull/2010.

