### PR TITLE
Add: Add scp_port as valid alert method data key

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -4460,6 +4460,7 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
                     || strcmp (name, "scp_host") == 0
                     || strcmp (name, "scp_known_hosts") == 0
                     || strcmp (name, "scp_path") == 0
+                    || strcmp (name, "scp_port") == 0
                     || strcmp (name, "scp_report_format") == 0))
             || (strcmp (method, "SMB") == 0
                 && (strcmp (name, "smb_credential") == 0


### PR DESCRIPTION
## What
This adds scp_port as a valid option in the checks in append_alert_method_data.

## Why
So it can be set by GSA as an option for SCP alerts.

## References
GEA-280
uses greenbone/gvmd#2057
