### PR TITLE
Add: Added an option to ignore the pagination for alert reports.

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -4511,7 +4511,8 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
             || strcmp (name, "delta_type") == 0
             || strcmp (name, "delta_report_id") == 0
             || strcmp (name, "composer_include_notes") == 0
-            || strcmp (name, "composer_include_overrides") == 0)
+            || strcmp (name, "composer_include_overrides") == 0
+            || strcmp (name, "composer_ignore_pagination") == 0)
           xml_string_append (xml, "<data><name>%s</name>%s</data>", name,
                              param->value ? param->value : "");
         else if (strcmp (method, "Email") == 0 && notice == 0


### PR DESCRIPTION
## What
The option Pagination was added to the "Compose Content for Scan Report" dialog for alerts. The default of this option is ignore, so that all results are included in the report regardless of the number of rows specified in the filter selected in the dialog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is an improvement that belongs to a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-124
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


