### PR TITLE
Add: compress responses in exec_gmp_get

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Prerequisites:
 * libmicrohttpd >= 0.9.0
 * pkg-config
 * gcc
+* zlib >= 1.2
 
 Prerequisites for building documentation:
 * Doxygen
@@ -72,7 +73,7 @@ Prerequisites for building documentation:
 Install prerequisites on Debian GNU/Linux:
 
 ```bash
-apt-get install libmicrohttpd-dev libxml2-dev
+apt-get install libmicrohttpd-dev libxml2-dev zlib1g-dev
 ```
 
 ### Compiling

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.6)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.6)
 pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=22.6)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
+pkg_check_modules (ZLIB REQUIRED zlib>=1.2)
 
 message (STATUS "Looking for libgcrypt...")
 find_library (LIBGCRYPT gcrypt)
@@ -48,13 +49,13 @@ endif (NOT LIBGCRYPT)
 if (NOT LIBMICROHTTPD_FOUND OR NOT LIBXML_FOUND OR NOT GLIB_FOUND OR
     (GTHREAD_REQUIRED AND NOT GTHREAD_FOUND) OR NOT
     LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT
-    LIBGCRYPT)
+    LIBGCRYPT OR NOT ZLIB_FOUND)
   message (FATAL_ERROR "One or more required libraries was not found "
     "(see message above), please install the missing "
     "libraries and run cmake again.")
 endif (NOT LIBMICROHTTPD_FOUND OR NOT LIBXML_FOUND OR NOT GLIB_FOUND OR
   (GTHREAD_REQUIRED AND NOT GTHREAD_FOUND) OR NOT
-  LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT LIBGCRYPT)
+  LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT LIBGCRYPT OR NOT ZLIB_FOUND)
 
 ## Program
 
@@ -71,7 +72,8 @@ include_directories (${LIBMICROHTTPD_INCLUDE_DIRS} ${LIBXML_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS}
                      ${LIBGVM_UTIL_INCLUDE_DIRS}
                      ${LIBGVM_GMP_INCLUDE_DIRS}
-                     ${GNUTLS_INCLUDE_DIRS})
+                     ${GNUTLS_INCLUDE_DIRS}
+                     ${ZLIB_INCLUDE_DIRS})
 
 find_package (Threads)
 
@@ -101,13 +103,13 @@ target_link_libraries (gsad ${LIBMICROHTTPD_LDFLAGS}
                             ${LIBXML_LDFLAGS}
                             ${LIBGCRYPT_LDFLAGS}
                             ${GNUTLS_LDFLAGS}
+                            ${ZLIB_LDFLAGS}
                             ${LIBGVM_BASE_LDFLAGS}
                             ${LIBGVM_UTIL_LDFLAGS}
                             ${LIBGVM_GMP_LDFLAGS}
                             ${LIBGVM_GMP_LDFLAGS}
                             ${CMAKE_THREAD_LIBS_INIT}
                             ${LINKER_HARDENING_FLAGS}
-                            z
                        )
 set_target_properties (gsad PROPERTIES LINKER_LANGUAGE C)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries (gsad ${LIBMICROHTTPD_LDFLAGS}
                             ${LIBGVM_GMP_LDFLAGS}
                             ${CMAKE_THREAD_LIBS_INIT}
                             ${LINKER_HARDENING_FLAGS}
+                            z
                        )
 set_target_properties (gsad PROPERTIES LINKER_LANGUAGE C)
 

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1157,7 +1157,7 @@ watch_client_connection (void *data)
  * @brief Check whether may compress response.
  *
  * @param[in]  con  HTTP Connection
- * 
+ *
  * @return 1 if may, else 0.
  */
 static int
@@ -1166,8 +1166,7 @@ may_compress_response (http_connection_t *con)
   const char *ae;
   const char *de;
 
-  ae = MHD_lookup_connection_value (con,
-                                    MHD_HEADER_KIND,
+  ae = MHD_lookup_connection_value (con, MHD_HEADER_KIND,
                                     MHD_HTTP_HEADER_ACCEPT_ENCODING);
   if (ae == NULL)
     return 0;
@@ -1178,11 +1177,8 @@ may_compress_response (http_connection_t *con)
   if (de == NULL)
     return 0;
 
-  if (((de == ae)
-       || (de[-1] == ',')
-       || (de[-1] == ' '))
-      && ((de[strlen ("deflate")] == '\0')
-          || (de[strlen ("deflate")] == ',')
+  if (((de == ae) || (de[-1] == ',') || (de[-1] == ' '))
+      && ((de[strlen ("deflate")] == '\0') || (de[strlen ("deflate")] == ',')
           || (de[strlen ("deflate")] == ';')))
     return 1;
 
@@ -1196,12 +1192,12 @@ may_compress_response (http_connection_t *con)
  * @param[in]  res       Response.
  * @param[out] comp_len  Compressed length.
  * @param[out] comp      Compressed response.
- * 
+ *
  * @return 1 on success, else 0.
  */
 static int
-compress_response (const size_t res_len, const char *res,
-                   size_t *comp_len, char **comp)
+compress_response (const size_t res_len, const char *res, size_t *comp_len,
+                   char **comp)
 {
   Bytef *cbuf;
   uLongf cbuf_size;
@@ -1210,15 +1206,11 @@ compress_response (const size_t res_len, const char *res,
   cbuf_size = compressBound (res_len);
   cbuf = g_malloc (cbuf_size);
 
-  ret = compress (cbuf,
-                  &cbuf_size,
-                  (const Bytef *) res,
-                  res_len);
+  ret = compress (cbuf, &cbuf_size, (const Bytef *) res, res_len);
 
-  if ((ret == Z_OK)
-      && (cbuf_size < res_len))
+  if ((ret == Z_OK) && (cbuf_size < res_len))
     {
-      *comp = (char*) cbuf;
+      *comp = (char *) cbuf;
       *comp_len = cbuf_size;
       return 1;
     }
@@ -1559,7 +1551,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   if (may_compress_response (con))
     {
       gsize comp_len;
-    
+
       if (compress_response (res_len, res, &comp_len, &comp))
         {
           free (res);
@@ -1574,8 +1566,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
                                               MHD_RESPMEM_MUST_FREE);
 
   if (comp)
-    MHD_add_response_header (response,
-                             MHD_HTTP_HEADER_CONTENT_ENCODING,
+    MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_ENCODING,
                              "deflate");
 
   if (watcher_data)

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -66,6 +66,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <zlib.h>
 /* This must follow the system includes. */
 #include "gsad_base.h"
 #include "gsad_credentials.h"
@@ -1153,6 +1154,80 @@ watch_client_connection (void *data)
     name##_gmp (&connection, credentials, params, response_data);
 
 /**
+ * @brief Check whether may compress response.
+ *
+ * @param[in]  con  HTTP Connection
+ * 
+ * @return 1 if may, else 0.
+ */
+static int
+may_compress_response (http_connection_t *con)
+{
+  const char *ae;
+  const char *de;
+
+  ae = MHD_lookup_connection_value (con,
+                                    MHD_HEADER_KIND,
+                                    MHD_HTTP_HEADER_ACCEPT_ENCODING);
+  if (ae == NULL)
+    return 0;
+  if (strcmp (ae, "*") == 0)
+    return 1;
+
+  de = strstr (ae, "deflate");
+  if (de == NULL)
+    return 0;
+
+  if (((de == ae)
+       || (de[-1] == ',')
+       || (de[-1] == ' '))
+      && ((de[strlen ("deflate")] == '\0')
+          || (de[strlen ("deflate")] == ',')
+          || (de[strlen ("deflate")] == ';')))
+    return 1;
+
+  return 0;
+}
+
+/**
+ * @brief Compress response.
+ *
+ * @param[in]  res_len   Response length.
+ * @param[in]  res       Response.
+ * @param[out] comp_len  Compressed length.
+ * @param[out] comp      Compressed response.
+ * 
+ * @return 1 on success, else 0.
+ */
+static int
+compress_response (const size_t res_len, const char *res,
+                   size_t *comp_len, char **comp)
+{
+  Bytef *cbuf;
+  uLongf cbuf_size;
+  int ret;
+
+  cbuf_size = compressBound (res_len);
+  cbuf = g_malloc (cbuf_size);
+
+  ret = compress (cbuf,
+                  &cbuf_size,
+                  (const Bytef *) res,
+                  res_len);
+
+  if ((ret == Z_OK)
+      && (cbuf_size < res_len))
+    {
+      *comp = (char*) cbuf;
+      *comp_len = cbuf_size;
+      return 1;
+    }
+
+  free (cbuf);
+  return 0;
+}
+
+/**
  * @brief Handle a complete GET request.
  *
  * After some input checking, depending on the cmd parameter of the connection,
@@ -1172,7 +1247,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   const int CMD_MAX_SIZE = 27; /* delete_trash_lsc_credential */
   params_t *params = con_info->params;
   gvm_connection_t connection;
-  char *res = NULL;
+  char *res = NULL, *comp;
   gsize res_len = 0;
   http_response_t *response;
   cmd_response_data_t *response_data;
@@ -1481,8 +1556,27 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   if (res_len == 0)
     res_len = strlen (res);
 
+  if (may_compress_response (con))
+    {
+      gsize comp_len;
+    
+      if (compress_response (res_len, res, &comp_len, &comp))
+        {
+          free (res);
+          res_len = comp_len;
+          res = comp;
+        }
+    }
+  else
+    comp = NULL;
+
   response = MHD_create_response_from_buffer (res_len, (void *) res,
                                               MHD_RESPMEM_MUST_FREE);
+
+  if (comp)
+    MHD_add_response_header (response,
+                             MHD_HTTP_HEADER_CONTENT_ENCODING,
+                             "deflate");
 
   if (watcher_data)
     {


### PR DESCRIPTION
## What

In exec_gmp_get, compress responses with deflate (zlib).

## Why

Speeds up data transfer by reducing size of transfer.  Helps especially when the network is slow and pages are sending many MB. For example, the edit_config_family request when editing family 'Databases' with 'good 2g' throttling:

```
  main: 58s
  patch: 6s
```

