### PR TITLE
Change: remove old arg from manager_connect

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -746,7 +746,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     }
 
   /* Connect to manager */
-  switch (manager_connect (credentials, &connection, response_data))
+  switch (manager_connect (credentials, &connection))
     {
     case 0:
       break;
@@ -1284,7 +1284,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     }
 
   /* Connect to manager */
-  switch (manager_connect (credentials, &connection, response_data))
+  switch (manager_connect (credentials, &connection))
     {
     case 0:
       break;

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -17023,14 +17023,12 @@ login (http_connection_t *con, params_t *params,
  *
  * @param[in]   credentials  Username and password for authentication.
  * @param[out]  connection   Connection to Manager on success.
- * @param[out]  response_data  Extra data return for the HTTP response.
  *
  * @return 0 success, 1 if manager closed connection, 2 if auth failed,
  *         3 on timeout, 4 failed to connect, -1 on error
  */
 int
-manager_connect (credentials_t *credentials, gvm_connection_t *connection,
-                 cmd_response_data_t *response_data)
+manager_connect (credentials_t *credentials, gvm_connection_t *connection)
 {
   gmp_authenticate_info_opts_t auth_opts;
 

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -36,7 +36,7 @@ void
 gmp_init (const gchar *, const gchar *, int);
 
 int
-manager_connect (credentials_t *, gvm_connection_t *, cmd_response_data_t *);
+manager_connect (credentials_t *, gvm_connection_t *);
 
 char *
 clone_gmp (gvm_connection_t *, credentials_t *, params_t *,

--- a/src/gsad_http_handler.c
+++ b/src/gsad_http_handler.c
@@ -594,7 +594,7 @@ handle_system_report (http_connection_t *connection, const char *method,
   response_data = cmd_response_data_new ();
 
   /* Connect to manager */
-  switch (manager_connect (credentials, &con, response_data))
+  switch (manager_connect (credentials, &con))
     {
     case 0: /* success */
       res = get_system_report_gmp_from_url (


### PR DESCRIPTION
## What

Remove response_data arg from manager_connect.

## Why

In the past this was used to set the return code, but the caller's now do it.

## References

Usage remove in c023ad363e430c72212d5da27354694296b49f4d.