### PR TITLE
Add: compress responses in exec_gmp_get with Brotli

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Prerequisites:
 * pkg-config
 * gcc
 * zlib >= 1.2
+* libbrotli (optional, for Brotli compression)
 
 Prerequisites for building documentation:
 * Doxygen

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.6)
 pkg_check_modules (LIBGVM_GMP REQUIRED libgvm_gmp>=22.6)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (ZLIB REQUIRED zlib>=1.2)
+pkg_check_modules (BROTLI libbrotlienc)
 
 message (STATUS "Looking for libgcrypt...")
 find_library (LIBGCRYPT gcrypt)
@@ -63,6 +64,9 @@ set (HARDENING_FLAGS            "-D_FORTIFY_SOURCE=2 -fstack-protector")
 set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 
 set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -Wformat -Wformat-security")
+if (BROTLI_FOUND)
+  set (CMAKE_C_FLAGS            "${CMAKE_C_FLAGS} -DHAVE_BROTLI=1")
+endif (BROTLI_FOUND)
 
 set (CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -Werror")
 set (CMAKE_C_FLAGS_RELEASE      "${CMAKE_C_FLAGS_RELEASE} ${HARDENING_FLAGS}")
@@ -73,7 +77,8 @@ include_directories (${LIBMICROHTTPD_INCLUDE_DIRS} ${LIBXML_INCLUDE_DIRS}
                      ${LIBGVM_UTIL_INCLUDE_DIRS}
                      ${LIBGVM_GMP_INCLUDE_DIRS}
                      ${GNUTLS_INCLUDE_DIRS}
-                     ${ZLIB_INCLUDE_DIRS})
+                     ${ZLIB_INCLUDE_DIRS}
+                     ${BROTLI_INCLUDE_DIRS})
 
 find_package (Threads)
 
@@ -104,6 +109,7 @@ target_link_libraries (gsad ${LIBMICROHTTPD_LDFLAGS}
                             ${LIBGCRYPT_LDFLAGS}
                             ${GNUTLS_LDFLAGS}
                             ${ZLIB_LDFLAGS}
+                            ${BROTLI_LDFLAGS}
                             ${LIBGVM_BASE_LDFLAGS}
                             ${LIBGVM_UTIL_LDFLAGS}
                             ${LIBGVM_GMP_LDFLAGS}

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1223,8 +1223,8 @@ may_brotli (http_connection_t *con)
  * @return 1 on success, else 0.
  */
 static int
-compress_response_deflate (const size_t res_len, const char *res, size_t *comp_len,
-                           char **comp)
+compress_response_deflate (const size_t res_len, const char *res,
+                           size_t *comp_len, char **comp)
 {
   Bytef *cbuf;
   uLongf cbuf_size;
@@ -1258,8 +1258,8 @@ compress_response_deflate (const size_t res_len, const char *res, size_t *comp_l
  * @return 1 on success, else 0.
  */
 static int
-compress_response_brotli (const size_t res_len, const char *res, size_t *comp_len,
-                          char **comp)
+compress_response_brotli (const size_t res_len, const char *res,
+                          size_t *comp_len, char **comp)
 {
   size_t cbuf_size;
   uint8_t *cbuf;
@@ -1268,13 +1268,9 @@ compress_response_brotli (const size_t res_len, const char *res, size_t *comp_le
   cbuf_size = BrotliEncoderMaxCompressedSize (res_len);
   cbuf = g_malloc (cbuf_size);
 
-  ret = BrotliEncoderCompress (BROTLI_DEFAULT_QUALITY,
-                               BROTLI_DEFAULT_WINDOW,
-                               BROTLI_DEFAULT_MODE,
-                               res_len,
-                               (uint8_t*) res,
-                               &cbuf_size,
-                               cbuf);
+  ret = BrotliEncoderCompress (BROTLI_DEFAULT_QUALITY, BROTLI_DEFAULT_WINDOW,
+                               BROTLI_DEFAULT_MODE, res_len, (uint8_t *) res,
+                               &cbuf_size, cbuf);
 
   if ((ret == BROTLI_TRUE) && (cbuf_size < res_len))
     {
@@ -1640,8 +1636,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     }
 #endif
 
-  if ((encoding == NULL)
-      && may_deflate (con))
+  if ((encoding == NULL) && may_deflate (con))
     {
       gsize comp_len;
 


### PR DESCRIPTION
## What

In exec_gmp_get, compress responses with Brotli.

This feature is only used if libbrotli is found at build time.

## Why

Speeds up data transfer by reducing size of transfer.

Results in smaller sizes than deflate. For example one `cmd=edit_config_family` request of 1.52MB:
```
br  73.04kB
de 107.38kB
```

## References

Recent PR for deflate: greenbone/gsad/pull/143
Brotli encoding C man page: https://man.archlinux.org/man/core/brotli/encode.h.3.en