### PR TITLE
Change: Add usage_type parameter to GMP get_reports.

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -8465,12 +8465,13 @@ char *
 get_reports_gmp (gvm_connection_t *connection, credentials_t *credentials,
                  params_t *params, cmd_response_data_t *response_data)
 {
-  const gchar *filter, *filter_id, *details;
+  const gchar *filter, *filter_id, *details, *usage_type;
   gmp_arguments_t *arguments;
 
   filter = params_value (params, "filter");
   filter_id = params_value (params, "filter_id");
   details = params_value (params, "details");
+  usage_type = params_value (params, "usage_type");
 
   arguments = gmp_arguments_new ();
 
@@ -8497,6 +8498,10 @@ get_reports_gmp (gvm_connection_t *connection, credentials_t *credentials,
   if (details && !str_equal (details, ""))
     {
       gmp_arguments_add (arguments, "details", details);
+    }
+  if (usage_type)
+    {
+      gmp_arguments_add (arguments, "usage_type", usage_type);
     }
 
   params_remove (params, "filter");

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -469,9 +469,9 @@ init_validator ()
   gvm_validator_add (validator, "port_range_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (
     validator, "resource_type",
-    "^(alert|asset|audit_report|cert_bund_adv|config|cpe|credential|cve|"
+    "^(alert|asset|audit_report|audit|cert_bund_adv|config|cpe|credential|cve|"
     "dfn_cert_adv|filter|group|host|info|nvt|note|os|ovaldef|override|"
-    "permission|port_list|report|report_config|report_format|result|role|scanner|"
+    "permission|policy|port_list|report|report_config|report_format|result|role|scanner|"
     "schedule|tag|target|task|ticket|tls_certificate|user|vuln|)$");
   gvm_validator_add (validator, "resource_id", "^[[:alnum:]\\-_.:\\/~]*$");
   gvm_validator_add (validator, "resources_action", "^(|add|set|remove)$");

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -469,7 +469,7 @@ init_validator ()
   gvm_validator_add (validator, "port_range_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (
     validator, "resource_type",
-    "^(alert|asset|cert_bund_adv|config|cpe|credential|cve|dfn_cert_adv|"
+    "^(alert|asset|audit_report|cert_bund_adv|config|cpe|credential|cve|dfn_cert_adv|"
     "filter|group|host|info|nvt|note|os|ovaldef|override|permission|port_list|"
     "report|report_config|report_format|result|role|scanner|schedule|tag|"
     "target|task|ticket|"

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -469,11 +469,10 @@ init_validator ()
   gvm_validator_add (validator, "port_range_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (
     validator, "resource_type",
-    "^(alert|asset|audit_report|cert_bund_adv|config|cpe|credential|cve|dfn_cert_adv|"
-    "filter|group|host|info|nvt|note|os|ovaldef|override|permission|port_list|"
-    "report|report_config|report_format|result|role|scanner|schedule|tag|"
-    "target|task|ticket|"
-    "tls_certificate|user|vuln|)$");
+    "^(alert|asset|audit_report|cert_bund_adv|config|cpe|credential|cve|"
+    "dfn_cert_adv|filter|group|host|info|nvt|note|os|ovaldef|override|"
+    "permission|port_list|report|report_config|report_format|result|role|scanner|"
+    "schedule|tag|target|task|ticket|tls_certificate|user|vuln|)$");
   gvm_validator_add (validator, "resource_id", "^[[:alnum:]\\-_.:\\/~]*$");
   gvm_validator_add (validator, "resources_action", "^(|add|set|remove)$");
   gvm_validator_add (

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -471,7 +471,8 @@ init_validator ()
     validator, "resource_type",
     "^(alert|asset|audit_report|audit|cert_bund_adv|config|cpe|credential|cve|"
     "dfn_cert_adv|filter|group|host|info|nvt|note|os|ovaldef|override|"
-    "permission|policy|port_list|report|report_config|report_format|result|role|scanner|"
+    "permission|policy|port_list|report|report_config|report_format|result|"
+    "role|scanner|"
     "schedule|tag|target|task|ticket|tls_certificate|user|vuln|)$");
   gvm_validator_add (validator, "resource_id", "^[[:alnum:]\\-_.:\\/~]*$");
   gvm_validator_add (validator, "resources_action", "^(|add|set|remove)$");


### PR DESCRIPTION
## What

- Add usage_type parameter to GMP get_reports.
- Allow sub-types (audit_report, audit and policy) as resource types

## Why

- get_reports can now be used to get a report by its usage type (scan/audit). This is used by GSA's dedicated views for both scan and audit reports.

## References
GEA-397
requires [greenbone/gvmd#2125](https://github.com/greenbone/gvmd/pull/2125)


