### PR TITLE
Fix: Remove test output of brotli compression

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1276,12 +1276,10 @@ compress_response_brotli (const size_t res_len, const char *res,
     {
       *comp = (char *) cbuf;
       *comp_len = cbuf_size;
-      g_warning ("%s: 1", __func__);
       return 1;
     }
 
   g_free (cbuf);
-  g_warning ("%s: 0", __func__);
   return 0;
 }
 #endif


### PR DESCRIPTION
## What
Remove test output of brotli compression

## Why
This was generating unnecessary log entries when brotli compression was enabled.
