### PR TITLE
Change: Allow to load fonts from the local server

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -167,6 +167,7 @@
   "form-action 'self'; "                     \
   "style-src-elem 'self' 'unsafe-inline'; "  \
   "style-src 'self' 'unsafe-inline'; "       \
+  "font-src 'self';"                         \
   "img-src 'self' blob:;"
 
 /**


### PR DESCRIPTION


## What

Allow to load fonts from the local server

## Why

Extend the content-security-policy to allow to load fronts from the local server. The styling of GSA might contain new fonts that can't be loaded otherwise.

## References

DEVOPS-1000


