### PR TITLE
Change: Update directory name for assets url handler

### DIFF
--- a/src/gsad_http_handler.c
+++ b/src/gsad_http_handler.c
@@ -769,7 +769,7 @@ make_url_handlers ()
   url_handler_add_func (url_handlers, "^/robots\\.txt$", handle_static_file);
 
   url_handler_add_func (url_handlers, "^/config\\.*js$", handle_static_config);
-  url_handler_add_func (url_handlers, "^/static/(img|js|css|media)/.+$",
+  url_handler_add_func (url_handlers, "^/assets/.+$",
                         handle_static_file);
   url_handler_add_func (url_handlers, "^/manual/.+$", handle_static_file);
 

--- a/src/gsad_http_handler.c
+++ b/src/gsad_http_handler.c
@@ -769,8 +769,7 @@ make_url_handlers ()
   url_handler_add_func (url_handlers, "^/robots\\.txt$", handle_static_file);
 
   url_handler_add_func (url_handlers, "^/config\\.*js$", handle_static_config);
-  url_handler_add_func (url_handlers, "^/assets/.+$",
-                        handle_static_file);
+  url_handler_add_func (url_handlers, "^/assets/.+$", handle_static_file);
   url_handler_add_func (url_handlers, "^/manual/.+$", handle_static_file);
 
   // Create /gmp handler.

--- a/src/gsad_http_handler.c
+++ b/src/gsad_http_handler.c
@@ -770,6 +770,8 @@ make_url_handlers ()
 
   url_handler_add_func (url_handlers, "^/config\\.*js$", handle_static_config);
   url_handler_add_func (url_handlers, "^/assets/.+$", handle_static_file);
+  url_handler_add_func (url_handlers, "^/static/(img|js|css|media)/.+$",
+                        handle_static_file);
   url_handler_add_func (url_handlers, "^/manual/.+$", handle_static_file);
 
   // Create /gmp handler.


### PR DESCRIPTION
## What

Update directory name for assets URL handler to `assets` instead of `static` and remove sub-directories.

## Why
After switching to Vite as a build tool for GSA, all assets are placed by default in the `assets` directory without creating sub-directories for each type.

## References
GEA-541


