### PR TITLE
Change: Adjust content security policy to allow inline javascript

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -163,6 +163,7 @@
   "base-uri 'none'; "                        \
   "connect-src 'self'; "                     \
   "script-src 'self'; "                      \
+  "script-src-elem 'self' 'unsafe-inline';"  \
   "frame-ancestors 'none'; "                 \
   "form-action 'self'; "                     \
   "style-src-elem 'self' 'unsafe-inline'; "  \


### PR DESCRIPTION


## What

Adjust content security policy to allow inline javascript

## Why

Inline javascript is used by the build tool to detect older versions of browsers. Without adjusting the content security policy we aren't able to support older browsers.


