### PR TITLE
Fix: Comments should be escaped when creating or modifying targets.

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -5336,7 +5336,8 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (allow_simultaneous_ips, "Create Target");
 
   if (comment != NULL)
-    comment_element = g_strdup_printf ("<comment>%s</comment>", comment);
+    comment_element =
+      g_markup_printf_escaped ("<comment>%s</comment>", comment);
   else
     comment_element = g_strdup ("");
 
@@ -6307,7 +6308,8 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
     entity_t entity;
 
     if (comment)
-      comment_element = g_strdup_printf ("<comment>%s</comment>", comment);
+      comment_element =
+        g_markup_printf_escaped ("<comment>%s</comment>", comment);
     else
       comment_element = g_strdup ("");
 


### PR DESCRIPTION
## What
Escape comments when creating or modifying targets.

## Why
Comments should be escaped but they were not. An error occurs when adding an ampersand to the comment field.

## References
GEA-562
