### PR TITLE
Add: Coverage CMake targets and Codecov upload

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -39,6 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     container: greenbone/gsad-build:stable
     steps:
+      - name: Install git for Codecov uploader
+        run: |
+          apt update
+          apt install --no-install-recommends -y ca-certificates git
+          rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v4
       - name: Configure and compile gsad
         run: |

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -42,7 +42,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure and compile gsad
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=1 .
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=1 -DENABLE_COVERAGE=1 .
           cmake --build build
       - name: Configure and run tests
         run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build -- tests test
+      - name: Upload test coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: build/coverage/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -56,3 +56,4 @@ jobs:
         with:
           file: build/coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,16 @@ set (GSAD_VERSION "${PROJECT_VERSION_STRING}")
 
 message (STATUS "Building gsad version ${GSAD_VERSION}")
 
+## Code coverage
+
+OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
+if (ENABLE_COVERAGE)
+  set (COVERAGE_FLAGS "--coverage -ftest-coverage -fprofile-arcs")
+  set (COVERAGE_DIR "${CMAKE_BINARY_DIR}/coverage")
+  file (MAKE_DIRECTORY ${COVERAGE_DIR})
+  message ("-- Code Coverage enabled")
+endif (ENABLE_COVERAGE)
+
 ## Files generated on installation
 
 # generate compile_commands.json file

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ endif (NOT LIBMICROHTTPD_FOUND OR NOT LIBXML_FOUND OR NOT GLIB_FOUND OR
 set (HARDENING_FLAGS            "-D_FORTIFY_SOURCE=2 -fstack-protector")
 set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 
-set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -Wformat -Wformat-security")
+set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -Wformat -Wformat-security ${COVERAGE_FLAGS}")
 if (BROTLI_FOUND)
   set (CMAKE_C_FLAGS            "${CMAKE_C_FLAGS} -DHAVE_BROTLI=1")
 endif (BROTLI_FOUND)
@@ -209,5 +209,19 @@ if (BUILD_TESTING)
                      gsad-validator-test
                      )
 endif(BUILD_TESTING)
+
+if (ENABLE_COVERAGE)
+  add_custom_target (coverage-html
+                     COMMAND gcovr --html-details ${COVERAGE_DIR}/coverage.html
+                     -r ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  add_custom_target (coverage-xml
+                     COMMAND gcovr --xml ${COVERAGE_DIR}/coverage.xml
+                     -r ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  add_custom_target (coverage DEPENDS coverage-xml coverage-html)
+endif (ENABLE_COVERAGE)
+
+add_custom_target (clean-coverage
+                   COMMAND find . -name *.gcda -delete -or -name *.gcno -delete
+                   COMMAND rm -f ${COVERAGE_DIR}/*)
 
 ## End


### PR DESCRIPTION
## What
This adds new targets for measuring unit test coverage that can be enabled with the CMake option ENABLE_COVERAGE.
The GitHub Actions workflow now also generates the coverage report and uploads it to Codecov.

## Why

<!-- Describe why are these changes necessary? -->

## References
GEA-604

