### PR TITLE
Add: Allow the update of setting variables for time and date formats

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -11984,7 +11984,9 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
 {
   const char *lang, *text, *old_passwd, *passwd, *max;
   const char *details_fname, *list_fname, *report_fname;
+  const char *time_format, *date_format;
   gchar *lang_64, *text_64, *max_64, *fname_64;
+  gchar *time_format_64, *date_format_64;
   GString *xml;
   entity_t entity;
   params_t *changed, *defaults, *filters;
@@ -12004,6 +12006,8 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
   details_fname = params_value (params, "details_fname");
   list_fname = params_value (params, "list_fname");
   report_fname = params_value (params, "report_fname");
+  time_format = params_value (params, "time_format");
+  date_format = params_value (params, "date_format");
 
   CHECK_VARIABLE_INVALID (text, "Save Settings")
   CHECK_VARIABLE_INVALID (text, "Save Settings")
@@ -12013,6 +12017,8 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (details_fname, "Save Settings")
   CHECK_VARIABLE_INVALID (list_fname, "Save Settings")
   CHECK_VARIABLE_INVALID (report_fname, "Save Settings")
+  CHECK_VARIABLE_INVALID (time_format, "Save Settings")
+  CHECK_VARIABLE_INVALID (date_format, "Save Settings")
 
   xml = g_string_new ("");
 
@@ -12621,6 +12627,110 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
         {
           g_string_free (xml, TRUE);
           gvm_connection_close (connection);
+          cmd_response_data_set_status_code (response_data,
+                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_message (
+            credentials, "Internal error", __func__, __LINE__,
+            "An internal error occurred while saving settings. "
+            "It is unclear whether all the settings were saved. "
+            "Diagnostics: Failure to receive response from manager daemon.",
+            response_data);
+        }
+      xml_string_append (xml, "</save_setting>");
+      if (gmp_success (entity) != 1)
+        {
+          set_http_status_from_entity (entity, response_data);
+          modify_failed = 1;
+        }
+    }
+
+  /* Send User Interface Time Format. */
+  changed_value = params_value (changed, "time_format");
+  if (changed_value == NULL
+      || (strcmp (changed_value, "") && strcmp (changed_value, "0")))
+    {
+      time_format_64 =
+        g_base64_encode ((guchar *) time_format, strlen (time_format));
+
+      if (gvm_connection_sendf (connection,
+                                "<modify_setting"
+                                " setting_id"
+                                "=\"11deb7ff-550b-4950-aacf-06faeb7c61b9\">"
+                                "<value>%s</value>"
+                                "</modify_setting>",
+                                time_format_64 ? time_format_64 : "")
+          == -1)
+        {
+          g_free (time_format_64);
+          cmd_response_data_set_status_code (response_data,
+                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_message (
+            credentials, "Internal error", __func__, __LINE__,
+            "An internal error occurred while saving settings. "
+            "It is unclear whether all the settings were saved. "
+            "Diagnostics: Failure to send command to manager daemon.",
+            response_data);
+        }
+      g_free (time_format_64);
+
+      entity = NULL;
+      xml_string_append (xml, "<save_setting id=\"%s\">",
+                         "11deb7ff-550b-4950-aacf-06faeb7c61b9");
+      if (read_entity_and_string_c (connection, &entity, &xml))
+        {
+          g_string_free (xml, TRUE);
+          cmd_response_data_set_status_code (response_data,
+                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_message (
+            credentials, "Internal error", __func__, __LINE__,
+            "An internal error occurred while saving settings. "
+            "It is unclear whether all the settings were saved. "
+            "Diagnostics: Failure to receive response from manager daemon.",
+            response_data);
+        }
+      xml_string_append (xml, "</save_setting>");
+      if (gmp_success (entity) != 1)
+        {
+          set_http_status_from_entity (entity, response_data);
+          modify_failed = 1;
+        }
+    }
+
+  /* Send User Interface Date Format. */
+  changed_value = params_value (changed, "date_format");
+  if (changed_value == NULL
+      || (strcmp (changed_value, "") && strcmp (changed_value, "0")))
+    {
+      date_format_64 =
+        g_base64_encode ((guchar *) date_format, strlen (date_format));
+
+      if (gvm_connection_sendf (connection,
+                                "<modify_setting"
+                                " setting_id"
+                                "=\"d9857b7c-1159-4193-9bc0-18fae5473a69\">"
+                                "<value>%s</value>"
+                                "</modify_setting>",
+                                date_format_64 ? date_format_64 : "")
+          == -1)
+        {
+          g_free (date_format_64);
+          cmd_response_data_set_status_code (response_data,
+                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_message (
+            credentials, "Internal error", __func__, __LINE__,
+            "An internal error occurred while saving settings. "
+            "It is unclear whether all the settings were saved. "
+            "Diagnostics: Failure to send command to manager daemon.",
+            response_data);
+        }
+      g_free (date_format_64);
+
+      entity = NULL;
+      xml_string_append (xml, "<save_setting id=\"%s\">",
+                         "d9857b7c-1159-4193-9bc0-18fae5473a69");
+      if (read_entity_and_string_c (connection, &entity, &xml))
+        {
+          g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -11986,7 +11986,6 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
   const char *details_fname, *list_fname, *report_fname;
   const char *time_format, *date_format;
   gchar *lang_64, *text_64, *max_64, *fname_64;
-  gchar *time_format_64, *date_format_64;
   GString *xml;
   entity_t entity;
   params_t *changed, *defaults, *filters;
@@ -12649,7 +12648,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
   if (changed_value == NULL
       || (strcmp (changed_value, "") && strcmp (changed_value, "0")))
     {
-      time_format_64 =
+      gchar *time_format_64 =
         g_base64_encode ((guchar *) time_format, strlen (time_format));
 
       if (gvm_connection_sendf (connection,
@@ -12701,7 +12700,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
   if (changed_value == NULL
       || (strcmp (changed_value, "") && strcmp (changed_value, "0")))
     {
-      date_format_64 =
+      gchar *date_format_64 =
         g_base64_encode ((guchar *) date_format, strlen (date_format));
 
       if (gvm_connection_sendf (connection,

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -545,8 +545,8 @@ init_validator ()
                      "^(second|minute|hour|day|week|month|year|decade)$");
   gvm_validator_add (validator, "chart_title", "(?s)^.*$");
   gvm_validator_add (validator, "icalendar", "(?s)^BEGIN:VCALENDAR.+$");
-  gvm_validator_add (validator, "time_format", "^(12|24)$");
-  gvm_validator_add (validator, "date_format", "^(wmdy|wdmy)$");
+  gvm_validator_add (validator, "time_format", "^(12|24|system_default)$");
+  gvm_validator_add (validator, "date_format", "^(wmdy|wdmy|system_default)$");
 
   /* Binary data params that should not use no UTF-8 validation */
   gvm_validator_add_binary (validator, "certificate_bin");

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -545,6 +545,8 @@ init_validator ()
                      "^(second|minute|hour|day|week|month|year|decade)$");
   gvm_validator_add (validator, "chart_title", "(?s)^.*$");
   gvm_validator_add (validator, "icalendar", "(?s)^BEGIN:VCALENDAR.+$");
+  gvm_validator_add (validator, "time_format", "^(12|24)$");
+  gvm_validator_add (validator, "date_format", "^(wmdy|wdmy)$");
 
   /* Binary data params that should not use no UTF-8 validation */
   gvm_validator_add_binary (validator, "certificate_bin");


### PR DESCRIPTION
## What
Allows the update of setting variables for time and date formats.

## Why
To allow updating time and date formats from GSA user settings independently of the language.

## References
GEA-430
requires [#2283](https://github.com/greenbone/gvmd/pull/2283)


