### PR TITLE
Fix: CMake: Use pkg-config instead of the dropped libgcrypt-config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,29 +34,17 @@ pkg_check_modules (ZLIB REQUIRED zlib>=1.2)
 pkg_check_modules (BROTLI libbrotlienc)
 
 message (STATUS "Looking for libgcrypt...")
-find_library (LIBGCRYPT gcrypt)
-if (NOT LIBGCRYPT)
-  message (SEND_ERROR "The libgcrypt library is required.")
-else (NOT LIBGCRYPT)
-  message (STATUS "Looking for libgcrypt... ${LIBGCRYPT}")
-  execute_process (COMMAND libgcrypt-config --libs
-    OUTPUT_VARIABLE LIBGCRYPT_LDFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process (COMMAND libgcrypt-config --cflags
-    OUTPUT_VARIABLE LIBGCRYPT_CFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif (NOT LIBGCRYPT)
+pkg_check_modules (GCRYPT REQUIRED libgcrypt)
 
 if (NOT LIBMICROHTTPD_FOUND OR NOT LIBXML_FOUND OR NOT GLIB_FOUND OR
     (GTHREAD_REQUIRED AND NOT GTHREAD_FOUND) OR NOT
-    LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT
-    LIBGCRYPT OR NOT ZLIB_FOUND)
+    LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT ZLIB_FOUND)
   message (FATAL_ERROR "One or more required libraries was not found "
     "(see message above), please install the missing "
     "libraries and run cmake again.")
 endif (NOT LIBMICROHTTPD_FOUND OR NOT LIBXML_FOUND OR NOT GLIB_FOUND OR
   (GTHREAD_REQUIRED AND NOT GTHREAD_FOUND) OR NOT
-  LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT LIBGCRYPT OR NOT ZLIB_FOUND)
+  LIBGVM_GMP_FOUND OR NOT GNUTLS_FOUND OR NOT ZLIB_FOUND)
 
 ## Program
 
@@ -106,7 +94,7 @@ target_link_libraries (gsad ${LIBMICROHTTPD_LDFLAGS}
                             ${GTHREAD_LDFLAGS}
                             ${GLIB_LDFLAGS}
                             ${LIBXML_LDFLAGS}
-                            ${LIBGCRYPT_LDFLAGS}
+                            ${GCRYPT_LDFLAGS}
                             ${GNUTLS_LDFLAGS}
                             ${ZLIB_LDFLAGS}
                             ${BROTLI_LDFLAGS}

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -7465,9 +7465,10 @@ save_config_nvt_gmp (gvm_connection_t *connection, credentials_t *credentials,
             }
           g_strfreev (splits);
 
-          value = preference->value_size ? g_base64_encode (
-                    (guchar *) preference->value, preference->value_size)
-                                         : g_strdup ("");
+          value = preference->value_size
+                    ? g_base64_encode ((guchar *) preference->value,
+                                       preference->value_size)
+                    : g_strdup ("");
 
           if (is_timeout)
             {


### PR DESCRIPTION
## What

Use pkg-config to configure libgcrypt.

## Why

libgcrypt-config has been dropped.

## References

Closes #181.