### PR TITLE
Add: Added the Kerberos credential type to gsad.

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -5566,7 +5566,7 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
     xml->str, comment_element, ssh_credentials_element,
     ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
     smb_credentials_element, esxi_credentials_element, snmp_credentials_element,
-    krb5_credentials_element, asset_hosts_element);
+    krb5_credentials_element ? : "", asset_hosts_element);
 
   g_string_free (xml, TRUE);
   g_free (comment_element);
@@ -6548,7 +6548,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       comment_element, ssh_credentials_element,
       ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
       smb_credentials_element, esxi_credentials_element,
-      krb5_credentials_element, snmp_credentials_element);
+      krb5_credentials_element ? : "", snmp_credentials_element);
 
     g_free (comment_element);
     g_free (ssh_credentials_element);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -5568,6 +5568,8 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
   g_free (ssh_elevate_credentials_element);
   g_free (smb_credentials_element);
   g_free (esxi_credentials_element);
+  g_free (krb5_credentials_element);
+  g_free (asset_hosts_element);
 
   ret =
     gmp (connection, credentials, &response, &entity, response_data, command);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -3122,23 +3122,21 @@ create_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
           CHECK_VARIABLE_INVALID (kdc, "Create Credential");
           CHECK_VARIABLE_INVALID (realm, "Create Credential");
 
-          ret =
-            gmpf (connection, credentials, &response, &entity, response_data,
-                  "<create_credential>"
-                  "<name>%s</name>"
-                  "<comment>%s</comment>"
-                  "<type>%s</type>"
-                  "<login>%s</login>"
-                  "<password>%s</password>"
-                  "<kdc>%s</kdc>"
-                  "<realm>%s</realm>"
-                  "<allow_insecure>%s</allow_insecure>"
-                  "</create_credential>",
-                  name, comment ? comment : "", type,
-                  credential_login ? credential_login : "",
-                  password ? password : "",
-                  kdc ? kdc : "", realm ? realm : "",
-                  allow_insecure);
+          ret = gmpf (
+            connection, credentials, &response, &entity, response_data,
+            "<create_credential>"
+            "<name>%s</name>"
+            "<comment>%s</comment>"
+            "<type>%s</type>"
+            "<login>%s</login>"
+            "<password>%s</password>"
+            "<kdc>%s</kdc>"
+            "<realm>%s</realm>"
+            "<allow_insecure>%s</allow_insecure>"
+            "</create_credential>",
+            name, comment ? comment : "", type,
+            credential_login ? credential_login : "", password ? password : "",
+            kdc ? kdc : "", realm ? realm : "", allow_insecure);
         }
       else if (str_equal (type, "usk"))
         {
@@ -3792,13 +3790,11 @@ save_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       if ((kdc && strcmp (kdc, "")))
         {
-          xml_string_append (command, "<kdc>%s</kdc>",
-                             kdc);
+          xml_string_append (command, "<kdc>%s</kdc>", kdc);
         }
       if ((realm && strcmp (realm, "")))
         {
-          xml_string_append (command, "<realm>%s</realm>",
-                             realm);
+          xml_string_append (command, "<realm>%s</realm>", realm);
         }
     }
   else if (str_equal (type, "cc"))
@@ -6537,8 +6533,8 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       "</modify_target>",
       comment_element, ssh_credentials_element,
       ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
-      smb_credentials_element, esxi_credentials_element, krb5_credentials_element,
-      snmp_credentials_element);
+      smb_credentials_element, esxi_credentials_element,
+      krb5_credentials_element, snmp_credentials_element);
 
     g_free (comment_element);
     g_free (ssh_credentials_element);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -3788,11 +3788,11 @@ save_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
     }
   else if (str_equal (type, "krb5"))
     {
-      if ((kdc && strcmp (kdc, "")))
+      if (kdc && strcmp (kdc, ""))
         {
           xml_string_append (command, "<kdc>%s</kdc>", kdc);
         }
-      if ((realm && strcmp (realm, "")))
+      if (realm && strcmp (realm, ""))
         {
           xml_string_append (command, "<realm>%s</realm>", realm);
         }
@@ -5470,7 +5470,8 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
     CHECK_VARIABLE_INVALID (target_ssh_elevate_credential, "Create Target");
   CHECK_VARIABLE_INVALID (target_smb_credential, "Create Target");
   CHECK_VARIABLE_INVALID (target_esxi_credential, "Create Target");
-  CHECK_VARIABLE_INVALID (target_krb5_credential, "Create Target");
+  if (params_given (params, "krb5_credential_id"))
+    CHECK_VARIABLE_INVALID (target_krb5_credential, "Create Target");
   CHECK_VARIABLE_INVALID (target_snmp_credential, "Create Target");
   CHECK_VARIABLE_INVALID (alive_tests, "Create Target");
   CHECK_VARIABLE_INVALID (allow_simultaneous_ips, "Create Target");
@@ -5511,11 +5512,17 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
     esxi_credentials_element =
       g_strdup_printf ("<esxi_credential id=\"%s\"/>", target_esxi_credential);
 
-  if (strcmp (target_krb5_credential, "0") == 0)
-    krb5_credentials_element = g_strdup ("");
+  if (target_krb5_credential)
+    {
+      if (strcmp (target_krb5_credential, "0") == 0)
+        krb5_credentials_element = g_strdup ("");
+      else
+        krb5_credentials_element =
+          g_strdup_printf ("<krb5_credential id=\"%s\"/>",
+                             target_krb5_credential);
+    }
   else
-    krb5_credentials_element =
-      g_strdup_printf ("<krb5_credential id=\"%s\"/>", target_krb5_credential);
+    krb5_credentials_element = NULL;
 
   if (strcmp (target_snmp_credential, "0") == 0)
     snmp_credentials_element = g_strdup ("");
@@ -6433,7 +6440,8 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (target_ssh_credential, "Save Target");
   CHECK_VARIABLE_INVALID (target_smb_credential, "Save Target");
   CHECK_VARIABLE_INVALID (target_esxi_credential, "Save Target");
-  CHECK_VARIABLE_INVALID (target_krb5_credential, "Save Target");
+  if (params_given (params, "krb5_credential_id"))
+    CHECK_VARIABLE_INVALID (target_krb5_credential, "Save Target");
   CHECK_VARIABLE_INVALID (target_snmp_credential, "Save Target");
   CHECK_VARIABLE_INVALID (allow_simultaneous_ips, "Save Target");
 
@@ -6496,11 +6504,16 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       esxi_credentials_element = g_strdup_printf (
         "<esxi_credential id=\"%s\"/>", target_esxi_credential);
 
-    if (str_equal (target_krb5_credential, "--"))
-      krb5_credentials_element = g_strdup ("");
+    if (target_krb5_credential)
+      {
+        if (str_equal (target_krb5_credential, "--"))
+          krb5_credentials_element = g_strdup ("");
+        else
+          krb5_credentials_element = g_strdup_printf (
+            "<krb5_credential id=\"%s\"/>", target_krb5_credential);
+      }
     else
-      krb5_credentials_element = g_strdup_printf (
-        "<krb5_credential id=\"%s\"/>", target_krb5_credential);
+      krb5_credentials_element = NULL;
 
     if (str_equal (target_snmp_credential, "--"))
       snmp_credentials_element = g_strdup ("");

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -5517,9 +5517,8 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       if (strcmp (target_krb5_credential, "0") == 0)
         krb5_credentials_element = g_strdup ("");
       else
-        krb5_credentials_element =
-          g_strdup_printf ("<krb5_credential id=\"%s\"/>",
-                             target_krb5_credential);
+        krb5_credentials_element = g_strdup_printf (
+          "<krb5_credential id=\"%s\"/>", target_krb5_credential);
     }
   else
     krb5_credentials_element = NULL;

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -5566,7 +5566,7 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
     xml->str, comment_element, ssh_credentials_element,
     ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
     smb_credentials_element, esxi_credentials_element, snmp_credentials_element,
-    krb5_credentials_element ? : "", asset_hosts_element);
+    krb5_credentials_element ?: "", asset_hosts_element);
 
   g_string_free (xml, TRUE);
   g_free (comment_element);
@@ -6548,7 +6548,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       comment_element, ssh_credentials_element,
       ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
       smb_credentials_element, esxi_credentials_element,
-      krb5_credentials_element ? : "", snmp_credentials_element);
+      krb5_credentials_element ?: "", snmp_credentials_element);
 
     g_free (comment_element);
     g_free (ssh_credentials_element);

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -311,7 +311,7 @@ init_validator ()
   gvm_validator_add (validator, "credential_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "create_credentials_type", "^(gen|pass|key)$");
   gvm_validator_add (validator, "credential_type",
-                     "^(cc|up|usk|smime|pgp|snmp|pw)$");
+                     "^(cc|up|usk|smime|pgp|snmp|krb5|pw)$");
   gvm_validator_add (validator, "credential_login", "^[-_[:alnum:]\\.@\\\\]*$");
   gvm_validator_add (validator, "condition_data:name", "^.*$");
   gvm_validator_add (validator, "condition_data:value", "(?s)^.*$");
@@ -707,6 +707,7 @@ init_validator ()
   gvm_validator_alias (validator, "show_all", "boolean");
   gvm_validator_alias (validator, "slave_id", "id");
   gvm_validator_alias (validator, "smb_credential_id", "credential_id");
+  gvm_validator_alias (validator, "krb5_credential_id", "credential_id");
   gvm_validator_alias (validator, "snmp_credential_id", "credential_id");
   gvm_validator_alias (validator, "ssh_credential_id", "credential_id");
   gvm_validator_alias (validator, "ssh_elevate_credential_id", "credential_id");


### PR DESCRIPTION

## What
The use of the Kerberos credential type is now also  allowed / possible in gsad.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This will later be used in scan targets for Kerberos 5 authentication.
<!-- Describe why are these changes necessary? -->

## References
GEA-776
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


