### PR TITLE
Fix: Add LIBDIR to SYSTEMD_SERVICE_DIR config

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 
 if (NOT SYSTEMD_SERVICE_DIR)
-  set (SYSTEMD_SERVICE_DIR "/lib/systemd/system")
+  set (SYSTEMD_SERVICE_DIR "${LIBDIR}/systemd/system")
 endif (NOT SYSTEMD_SERVICE_DIR)
 
 if (NOT LOGROTATE_DIR)


### PR DESCRIPTION
## What


By default install the systemd files into `/usr/local/lib/systemd/system`.

## Why


`/lib` is only a symlink to `/usr/lib` with the [usr merge](https://wiki.debian.org/UsrMerge) process. 
`/lib` being only symlink let the Dockerfile copy command `COPY /install/ /` fail with Debian >= bookworm.

Implement a similar change as in https://github.com/greenbone/gvmd/pull/2304

Tested the Docker build locally.

## References

https://jira.greenbone.net/browse/GEA-791
