### PR TITLE
Handle manual URL as static content

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -182,7 +182,7 @@
 #define DEFAULT_GSAD_PER_IP_CONNECTION_LIMIT 30
 
 #define COPYRIGHT                                                        \
-  "Copyright (C) 2010 - 2021 Greenbone AG\n"                             \
+  "Copyright (C) 2010 - 2025 Greenbone AG\n"                             \
   "License: AGPL-3.0-or-later\n"                                         \
   "This is free software: you are free to change and redistribute it.\n" \
   "There is NO WARRANTY, to the extent permitted by law.\n\n"

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -717,6 +717,7 @@ file_content_response (http_connection_t *connection, const char *url,
   if ((buf.st_mode & S_IFMT) != S_IFREG)
     {
       fclose (file);
+      g_debug ("Path %s is not a file.", path);
       return create_not_found_response (response_data);
     }
 


### PR DESCRIPTION


## What

Handle manual URL as static content

## Why

For static content an index.html is returned if available when a directory is requested. If the URL points to a directory but the URL doesn't end with a slash a redirect response with a URL including the slash is returned. With this change gsad behaves more like a "normal" http server when serving static content for the manual.

## References

https://jira.greenbone.net/browse/GEA-892


