### PR TITLE
Simplify logging configuration

### DIFF
--- a/.docker/gsad_log.conf
+++ b/.docker/gsad_log.conf
@@ -1,27 +1,18 @@
 [gsad main]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=-
-level=127
+level=info
 
 [gsad  gmp]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=-
-level=127
+level=info
+
+[gsad http handler]
+level=info
 
 [gsad http]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=-
-level=127
+level=info
 
 [*]
 prepend=%t %s %p
 separator=:
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=-
-level=16
+level=warning

--- a/README.md
+++ b/README.md
@@ -137,21 +137,25 @@ Logging is configured entirely by the file
 
 The configuration is divided into domains like this one
 
-    [gsad main]
-    prepend=%t %p
-    prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-    file=/var/log/gvm/gsad.log
-    level=128
+```ini
+[gsad main]
+prepend=%t %p
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/gsad.log
+level=debug
+```
 
 The `level` field controls the amount of logging that is written.
 The value of `level` can be:
 
-      4  Errors.
-      8  Critical situation.
-     16  Warnings.
-     32  Messages.
-     64  Information.
-    128  Debug.  (Lots of output.)
+```text
+error      4  Errors.
+critical   8  Critical situation.
+warning   16  Warnings.
+message   32  Messages.
+info      64  Information.
+debug    128  Debug.  (Lots of output.)
+```
 
 Enabling any level includes all the levels above it. So enabling Information
 will include Warnings, Critical situations and Errors.
@@ -161,12 +165,14 @@ configuration file.
 
 Logging to `syslog` can be enabled in each domain like:
 
-    [gsad main]
-    prepend=%t %p
-    prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-    file=syslog
-    syslog_facility=daemon
-    level=128
+```ini
+[gsad main]
+prepend=%t %p
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=syslog
+syslog_facility=daemon
+level=debug
+```
 
 ## Usage
 

--- a/src/gsad_log_conf.cmake_in
+++ b/src/gsad_log_conf.cmake_in
@@ -4,43 +4,20 @@
 #          group to include debug may reveal passwords in the logs.
 
 [gsad main]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GSAD_LOG_FILE}
-level=127
+level=info
 
-[gsad  gmp]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GSAD_LOG_FILE}
-level=127
-
-[gsad i18n]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GSAD_LOG_FILE}
-level=127
+[gsad gmp]
+level=info
 
 [gsad http]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GSAD_LOG_FILE}
-level=127
+level=info
 
-[gsad vali]
-prepend=%t %s %p
-separator=:
-prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
-file=${GSAD_LOG_FILE}
-level=127
+[gsad http handler]
+level=info
 
 [*]
 prepend=%t %s %p
 separator=:
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GSAD_LOG_FILE}
-level=0
+level=warning


### PR DESCRIPTION


## What

Simplify logging configuration

## Why

The `*` section sets the default of all other logging categories. Therefore only the different values need to be set. Additionally use the level names instead of the numbers. It's difficult to remember which number represents wich level in glib logging.
