### PR TITLE
Fix typo in logging domain for gsad_gmp module

### DIFF
--- a/.docker/gsad_log.conf
+++ b/.docker/gsad_log.conf
@@ -1,7 +1,7 @@
 [gsad main]
 level=info
 
-[gsad  gmp]
+[gsad gmp]
 level=info
 
 [gsad http handler]

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -63,7 +63,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "gsad  gmp"
+#define G_LOG_DOMAIN "gsad gmp"
 
 /**
  * @brief Manager (gvmd) address.


### PR DESCRIPTION

## What

Fix typo in logging domain for gsad_gmp module

## Why

The logging domain contained an extra space.

## References

https://github.com/greenbone/gsad/pull/194

