### PR TITLE
Fix: check passwd in save_my_settings_gmp

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -12093,7 +12093,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
   date_format = params_value (params, "date_format");
 
   CHECK_VARIABLE_INVALID (text, "Save Settings")
-  CHECK_VARIABLE_INVALID (text, "Save Settings")
+  CHECK_VARIABLE_INVALID (passwd, "Save Settings")
   CHECK_VARIABLE_INVALID (old_passwd, "Save Settings")
   CHECK_VARIABLE_INVALID (max, "Save Settings")
   CHECK_VARIABLE_INVALID (lang, "Save Settings")


### PR DESCRIPTION
## What

Add missing check of `passwd`.

## Why

All the params should be checked. `text` was being checked twice.

## References

This looks like a typo from e2e43458b9975a11130c3efe7c2c861ece4e74b8. See line [17139](https://github.com/greenbone/gsad/commit/e2e43458b9975a11130c3efe7c2c861ece4e74b8#diff-b581a6dd0d2f741e26f074617e97ac04b34bced71b0a82c92d5cb5ff5d176420L17139) of gsad_gmp.c.