### PR TITLE
Use correct container image URL for running unit tests

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -42,7 +42,7 @@ jobs:
   unittests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    container: greenbone/gvm-libs:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
     steps:
       - name: Install git for Codecov uploader
         run: |


### PR DESCRIPTION


## What

Use correct container image URL for running unit tests

## Why

Don't use an outdated and now unavailable container image URL for gvm-libs stable image.


