### PR TITLE
Add: Add get, list, and delete agent installer commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,13 @@ set(GSAD_VERSION "${PROJECT_VERSION_STRING}")
 
 message(STATUS "Building gsad version ${GSAD_VERSION}")
 
+# Feature toggles
+
+if(NOT ENABLE_AGENTS)
+  set(ENABLE_AGENTS 0)
+endif(NOT ENABLE_AGENTS)
+add_definitions(-DENABLE_AGENTS=${ENABLE_AGENTS})
+
 ## Code coverage
 
 option(ENABLE_COVERAGE "Enable support for coverage analysis" OFF)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ In case you have installed the Greenbone Security Assistant Daemon into a path
 different from the other GVM modules, you might need to set some paths
 explicitly before running `cmake`. See the top-level CMakeLists.txt.
 
+### Unit tests
+
+In order to build and run unit tests use the commands below: 
+
+```sh
+cmake -DBUILD_TESTING=1 ..  # enable building unit tests
+make tests                  # build the unit tests
+make test                   # run the unit tests
+```
+
 ## Logging Configuration
 
 By default, gsad writes logs to the file

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -838,7 +838,9 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (create_tls_certificate)
   ELSE (create_user)
   ELSE (create_role)
+#if ENABLE_AGENTS
   ELSE (delete_agent_installer)
+#endif
   ELSE (delete_asset)
   ELSE (delete_alert)
   ELSE (delete_config)
@@ -1517,9 +1519,11 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (export_tasks)
   ELSE (export_user)
   ELSE (export_users)
+#if ENABLE_AGENTS
   ELSE (get_agent_installers)
   ELSE (get_agent_installer)
   ELSE (get_agent_installer_file)
+#endif
   ELSE (get_asset)
   ELSE (get_assets)
 

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -838,6 +838,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (create_tls_certificate)
   ELSE (create_user)
   ELSE (create_role)
+  ELSE (delete_agent_installer)
   ELSE (delete_asset)
   ELSE (delete_alert)
   ELSE (delete_config)
@@ -1516,6 +1517,9 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (export_tasks)
   ELSE (export_user)
   ELSE (export_users)
+  ELSE (get_agent_installers)
+  ELSE (get_agent_installer)
+  ELSE (get_agent_installer_file)
   ELSE (get_asset)
   ELSE (get_assets)
 

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -17717,6 +17717,7 @@ save_license_gmp (gvm_connection_t *connection, credentials_t *credentials,
   return ret;
 }
 
+#if ENABLE_AGENTS
 /**
  * @brief Get agent installers.
  *
@@ -17870,6 +17871,7 @@ delete_agent_installer_gmp (gvm_connection_t *connection,
   return move_resource_to_trash (connection, "agent_installer", credentials,
                                  params, response_data);
 }
+#endif
 
 char *
 renew_session_gmp (gvm_connection_t *connection, credentials_t *credentials,

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -17717,6 +17717,160 @@ save_license_gmp (gvm_connection_t *connection, credentials_t *credentials,
   return ret;
 }
 
+/**
+ * @brief Get agent installers.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Credentials for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_agent_installers_gmp (gvm_connection_t *connection,
+                          credentials_t *credentials, params_t *params,
+                          cmd_response_data_t *response_data)
+{
+  return get_many (connection, "agent_installers", credentials, params, NULL,
+                   response_data);
+}
+
+/**
+ * @brief Get a single agent installer.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Credentials for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_agent_installer_gmp (gvm_connection_t *connection,
+                         credentials_t *credentials, params_t *params,
+                         cmd_response_data_t *response_data)
+{
+  return get_one (connection, "agent_installer", credentials, params, NULL,
+                  NULL, response_data);
+}
+
+/**
+ * @brief Get an agent installer file.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Credentials for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_agent_installer_file_gmp (gvm_connection_t *connection,
+                              credentials_t *credentials, params_t *params,
+                              cmd_response_data_t *response_data)
+{
+  const gchar *id = params_value (params, "agent_installer_id");
+  entity_t entity = NULL;
+  entity_t file_entity = NULL;
+  const gchar *format = NULL;
+  const gchar *name = NULL;
+  const gchar *content_type = NULL;
+  char *content = NULL;
+
+  if (!id || strlen (id) == 0)
+    {
+      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      return gsad_message (
+        credentials, "Missing installer ID", __func__, __LINE__,
+        "The 'agent_installer_id' parameter is required.", response_data);
+    }
+
+  // Send request
+  if (gvm_connection_sendf (
+        connection, "<get_agent_installer_file agent_installer_id=\"%s\"/>", id)
+      == -1)
+    {
+      cmd_response_data_set_status_code (response_data,
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_message (credentials, "GMP send failed", __func__, __LINE__,
+                           "Failed to send GMP command to retrieve installer.",
+                           response_data);
+    }
+
+  // Parse response
+  if (read_entity_c (connection, &entity))
+    {
+      cmd_response_data_set_status_code (response_data,
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_message (
+        credentials, "GMP receive failed", __func__, __LINE__,
+        "Failed to receive installer file response.", response_data);
+    }
+
+  file_entity = entity_child (entity, "agent_installer");
+
+  if (!file_entity || !entity_text (file_entity))
+    {
+      free_entity (entity);
+      cmd_response_data_set_status_code (response_data,
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_message (credentials, "No installer file", __func__, __LINE__,
+                           "No agent installer content was returned.",
+                           response_data);
+    }
+
+  format = entity_attribute (file_entity, "file_extension");
+  name = entity_attribute (file_entity, "name");
+  content_type = entity_attribute (file_entity, "content_type");
+
+  if (!format || strlen (format) == 0)
+    format = "";
+
+  if (!name || strlen (name) == 0)
+    name = "agent_installer";
+
+  if (!content_type || strlen (content_type) == 0)
+    {
+      cmd_response_data_set_content_type (response_data,
+                                          GSAD_CONTENT_TYPE_OCTET_STREAM);
+    }
+  else
+    {
+      cmd_response_data_set_content_type_string (response_data,
+                                                 g_strdup (content_type));
+    }
+
+  content = strdup (entity_text (file_entity));
+
+  cmd_response_data_set_content_disposition (
+    response_data,
+    g_strdup_printf ("attachment; filename=%s.%s", name, format));
+  cmd_response_data_set_content_length (response_data, strlen (content));
+
+  free_entity (entity);
+  return content;
+}
+
+/**
+ * @brief Delete an agent installer.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Credentials for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+delete_agent_installer_gmp (gvm_connection_t *connection,
+                            credentials_t *credentials, params_t *params,
+                            cmd_response_data_t *response_data)
+{
+  return move_resource_to_trash (connection, "agent_installer", credentials,
+                                 params, response_data);
+}
+
 char *
 renew_session_gmp (gvm_connection_t *connection, credentials_t *credentials,
                    params_t *params, cmd_response_data_t *response_data)

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -806,6 +806,22 @@ get_capabilities_gmp (gvm_connection_t *, credentials_t *, params_t *,
                       cmd_response_data_t *);
 
 char *
+get_agent_installers_gmp (gvm_connection_t *, credentials_t *, params_t *,
+                          cmd_response_data_t *);
+
+char *
+get_agent_installer_gmp (gvm_connection_t *, credentials_t *, params_t *,
+                         cmd_response_data_t *);
+
+char *
+get_agent_installer_file_gmp (gvm_connection_t *, credentials_t *, params_t *,
+                              cmd_response_data_t *);
+
+char *
+delete_agent_installer_gmp (gvm_connection_t *, credentials_t *, params_t *,
+                            cmd_response_data_t *);
+
+char *
 renew_session_gmp (gvm_connection_t *, credentials_t *, params_t *,
                    cmd_response_data_t *);
 char *

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -805,6 +805,7 @@ char *
 get_capabilities_gmp (gvm_connection_t *, credentials_t *, params_t *,
                       cmd_response_data_t *);
 
+#if ENABLE_AGENTS
 char *
 get_agent_installers_gmp (gvm_connection_t *, credentials_t *, params_t *,
                           cmd_response_data_t *);
@@ -820,6 +821,7 @@ get_agent_installer_file_gmp (gvm_connection_t *, credentials_t *, params_t *,
 char *
 delete_agent_installer_gmp (gvm_connection_t *, credentials_t *, params_t *,
                             cmd_response_data_t *);
+#endif
 
 char *
 renew_session_gmp (gvm_connection_t *, credentials_t *, params_t *,

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -65,6 +65,7 @@ init_validator ()
                      "|(delete_asset)"
                      "|(delete_config)"
                      "|(delete_credential)"
+                     "|(delete_agent_installer)"
                      "|(delete_alert)"
                      "|(delete_filter)"
                      "|(delete_from_trash)"
@@ -137,6 +138,9 @@ init_validator ()
                      "|(export_tasks)"
                      "|(export_user)"
                      "|(export_users)"
+                     "|(get_agent_installers)"
+                     "|(get_agent_installer)"
+                     "|(get_agent_installer_file)"
                      "|(get_aggregate)"
                      "|(get_alert)"
                      "|(get_alerts)"
@@ -556,6 +560,7 @@ init_validator ()
 
   gvm_validator_alias (validator, "optional_task_id", "optional_id");
   gvm_validator_alias (validator, "add_tag", "boolean");
+  gvm_validator_alias (validator, "agent_installer_id", "id");
   gvm_validator_alias (validator, "alert_id_2", "alert_id");
   gvm_validator_alias (validator, "alert_id_optional:name", "number");
   gvm_validator_alias (validator, "alert_id_optional:value",

--- a/src/gsad_validator_test.c
+++ b/src/gsad_validator_test.c
@@ -76,11 +76,27 @@ Ensure (gsad_validator, validate_comment)
                is_equal_to (0));
 }
 
+Ensure (gsad_validator, validate_agent_installer_id)
+{
+  validator_t validator = get_validator ();
+  assert_that (gvm_validate (validator, "agent_installer_id", "a1b2c3d4"),
+               is_equal_to (0));
+  assert_that (gvm_validate (validator, "agent_installer_id",
+                             "123e4567-e89b-12d3-a456-426614174000"),
+               is_equal_to (0));
+  assert_that (gvm_validate (validator, "agent_installer_id", ""),
+               is_equal_to (2));
+  assert_that (
+    gvm_validate (validator, "agent_installer_id", "invalid id with space"),
+    is_equal_to (2));
+}
+
 int
 main (int argc, char **argv)
 {
   TestSuite *suite = create_test_suite ();
   add_test_with_context (suite, gsad_validator, validate_name);
   add_test_with_context (suite, gsad_validator, validate_comment);
+  add_test_with_context (suite, gsad_validator, validate_agent_installer_id);
   return run_test_suite (suite, create_text_reporter ());
 }


### PR DESCRIPTION
## What

Added GMP support for:

- `get_agent_installers_gmp`: List available agent installers
- `get_agent_installer_gmp`: Get metadata for a single agent installer
- `get_agent_installer_file_gmp`: Get the installer file (base64-encoded)
- `delete_agent_installer_gmp`: Delete an agent installer


## Why

These changes are needed for Agent Installer integration.
## References

GEA-1038

## Checklist

- [ ] Tests


