### PR TITLE
Add: Add support for <kdcs> element in create_credential_gmp and save_credential_gmp

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -427,7 +427,7 @@ params_append_mhd (params_t *params, const char *name, const char *filename,
       || (strcmp (name, "group_ids:") == 0)
       || (strcmp (name, "report_format_ids:") == 0)
       || (strcmp (name, "id_list:") == 0)
-      || (strcmp (name, "resource_ids:") == 0))
+      || (strcmp (name, "resource_ids:") == 0) || (strcmp (name, "kdcs:") == 0))
     {
       param_t *param;
       gchar *index_str;

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -454,6 +454,8 @@ init_validator ()
   gvm_validator_add (validator, "ca_pub", "(?s)^.*$");
   gvm_validator_add (validator, "which_cert", "^(default|existing|new)$");
   gvm_validator_add (validator, "kdc", "(?s)^.*$");
+  gvm_validator_alias (validator, "kdcs:name", "number");
+  gvm_validator_alias (validator, "kdcs:value", "kdc");
   gvm_validator_add (validator, "key_pub", "(?s)^.*$");
   gvm_validator_add (validator, "key_priv", "(?s)^.*$");
   gvm_validator_add (validator, "radiuskey", "^.*$");

--- a/src/gsad_validator_test.c
+++ b/src/gsad_validator_test.c
@@ -106,6 +106,27 @@ Ensure (gsad_validator, validate_agent_list_ids)
     is_equal_to (2));
 }
 
+Ensure (gsad_validator, validate_kdcs_name_and_value)
+{
+  validator_t validator = get_validator ();
+
+  // valid KDC values (allowing anything, as per regex "(?s)^.*$")
+  assert_that (gvm_validate (validator, "kdcs:value", "127.0.0.1"),
+               is_equal_to (0));
+  assert_that (gvm_validate (validator, "kdcs:value", "kdc1"), is_equal_to (0));
+  assert_that (gvm_validate (validator, "kdcs:value", "kdc.example.internal"),
+               is_equal_to (0));
+  assert_that (gvm_validate (validator, "kdcs:value", ""), is_equal_to (0));
+
+  // invalid example for edge case
+  assert_that (gvm_validate (validator, "kdcs:value", NULL), is_equal_to (5));
+
+  // "kdcs:name" uses alias to "number", expect it to fail non-numeric
+  assert_that (gvm_validate (validator, "kdcs:name", "1"), is_equal_to (0));
+  assert_that (gvm_validate (validator, "kdcs:name", "abc"), is_equal_to (2));
+  assert_that (gvm_validate (validator, "kdcs:name", ""), is_equal_to (2));
+}
+
 int
 main (int argc, char **argv)
 {
@@ -114,5 +135,6 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_validator, validate_comment);
   add_test_with_context (suite, gsad_validator, validate_agent_installer_id);
   add_test_with_context (suite, gsad_validator, validate_agent_list_ids);
+  add_test_with_context (suite, gsad_validator, validate_kdcs_name_and_value);
   return run_test_suite (suite, create_text_reporter ());
 }


### PR DESCRIPTION
## What

This PR adds support for handling the` <kdcs>` XML element when creating or saving Kerberos credentials via `create_credential_gmp` and `save_credential_gmp`

## Why

This update enables full support for ` <kdcs>`  and ` <kdc>` tags,  improves Kerberos setups

## References

GEA-1128

## Checklist

- [ ] Tests


