### PR TITLE
Introduce new change_password API command

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -812,6 +812,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     }
   ELSE (bulk_delete)
   ELSE (bulk_export)
+  ELSE (change_password)
   ELSE (clone)
   ELSE (create_alert)
   ELSE (create_asset)

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -865,6 +865,10 @@ char *
 ping_gmp (gvm_connection_t *, credentials_t *, params_t *,
           cmd_response_data_t *);
 
+char *
+change_password_gmp (gvm_connection_t *, credentials_t *, params_t *,
+                     cmd_response_data_t *);
+
 int
 login (http_connection_t *con, params_t *params,
        cmd_response_data_t *response_data, const char *client_address);

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -34,6 +34,7 @@ init_validator ()
   gvm_validator_add (validator, "cmd",
                      "^((bulk_delete)"
                      "|(bulk_export)"
+                     "|(change_password)"
                      "|(clone)"
                      "|(create_asset)"
                      "|(create_config)"


### PR DESCRIPTION


## What

Introduce new change_password API command

## Why

Allow to change the password in a single command instead of using save_my_settings.

## References
https://jira.greenbone.net/browse/GEA-1144


