### PR TITLE
Change: Update get credential command to include OCI image targets.

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -3444,6 +3444,9 @@ get_credential (gvm_connection_t *connection, credentials_t *credentials,
 {
   gmp_arguments_t *arguments = gmp_arguments_new ();
   gmp_arguments_add (arguments, "targets", "1");
+#if ENABLE_CONTAINER_SCANNING
+  gmp_arguments_add (arguments, "oci_image_targets", "1");
+#endif
   gmp_arguments_add (arguments, "scanners", "1");
   return get_one (connection, "credential", credentials, params, extra_xml,
                   arguments, response_data);

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -694,6 +694,13 @@ get_trash_tags_gmp (gvm_connection_t *, credentials_t *, params_t *params,
 char *
 get_trash_targets_gmp (gvm_connection_t *, credentials_t *, params_t *params,
                        cmd_response_data_t *);
+
+#if ENABLE_CONTAINER_SCANNING
+char *
+get_trash_oci_image_targets_gmp (gvm_connection_t *, credentials_t *,
+                                 params_t *params, cmd_response_data_t *);
+#endif
+
 char *
 get_trash_tasks_gmp (gvm_connection_t *, credentials_t *, params_t *params,
                      cmd_response_data_t *);


### PR DESCRIPTION
## What

Include OCI image targets to get credential GMP command.

## Why
The credentials details page in GSA displays the targets using the credential. To keep consistent behavior for OCI image targets.

Changes are behind a toggle `ENABLE_CONTAINER_SCANNING`

requires https://github.com/greenbone/gvmd/pull/2490

## References

GEA-1180


