### PR TITLE
Allow to run our CI pipeline from GitHub forks

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -28,7 +28,7 @@ jobs:
           - stable
           - oldstable
           - testing
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:${{ matrix.container }}
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
@@ -42,7 +42,7 @@ jobs:
   unittests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:stable
     steps:
       - name: Install git for Codecov uploader
         run: |
@@ -59,6 +59,7 @@ jobs:
       - name: Configure and run tests
         run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build build -- tests test
       - name: Upload test coverage to Codecov
+        if: github.repository == 'greenbone/gsad'
         uses: codecov/codecov-action@v5
         with:
           files: build/coverage/coverage.xml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,10 +8,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
+      - "**/*.md"
+      - "**/*.txt"
   schedule:
-    - cron: '30 5 * * 0' # 5:30h on Sundays
+    - cron: "30 5 * * 0" # 5:30h on Sundays
 
 jobs:
   analyze:
@@ -21,24 +21,24 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: ${{ vars.SELF_HOSTED_REGISTRY }}/community/gvm-libs:stable
+    container: ${{ vars.SELF_HOSTED_REGISTRY || 'registry.community.greenbone.net' }}/community/gvm-libs:stable
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: C
-      # build between init and analyze ...
-    - name: Install build dependencies
-      run: sh .github/install-dependencies.sh .github/build-dependencies.list
-    - name: Configure and compile gsad
-      run: |
-        mkdir build
-        rm -rf .git
-        cd build/
-        cmake -DCMAKE_BUILD_TYPE=Debug ..
-        make install
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: C
+        # build between init and analyze ...
+      - name: Install build dependencies
+        run: sh .github/install-dependencies.sh .github/build-dependencies.list
+      - name: Configure and compile gsad
+        run: |
+          mkdir build
+          rm -rf .git
+          cd build/
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
+          make install
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,10 +2,10 @@ name: Build and Push Container Images
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref-name:
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'greenbone/gsad'
     name: Build and Push to Greenbone Registry
     uses: greenbone/workflows/.github/workflows/container-build-push-2nd-gen.yml@main
     with:


### PR DESCRIPTION


## What

Allow to run our CI pipeline from GitHub forks

## Why

Allow to run most parts of the CI/CD pipeline on forks too.

For whatever reason the vars GitHub context is not available in forks. Therefore the container couldn't be downloaded.

## References
https://github.com/greenbone/gsad/pull/216


