### PR TITLE
Enable auto-merge rebase for each PR

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,11 @@
+name: Auto-merge rebase
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: greenbone/workflows/.github/workflows/auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION

## What

Enable auto-merge rebase for each PR

## Why

Set auto-merge to rebase for each PR by default without user interaction. This allows to merge a PR after an approval automatically.
