### PR TITLE
Allow images to be delivered as src="data:"

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -169,7 +169,7 @@
   "style-src-elem 'self' 'unsafe-inline'; "  \
   "style-src 'self' 'unsafe-inline'; "       \
   "font-src 'self';"                         \
-  "img-src 'self' blob:;"
+  "img-src 'self' blob: data:;"
 
 /**
  * @brief Default "max-age" for HTTP header "Strict-Transport-Security"


### PR DESCRIPTION
## What

Allow images to be delivered as src="data:"

## Why

Extends our default content security policy to allow images be provided as `<img src="data:..."/>`. This is used to provide the charts for the system reports.

## References

https://jira.greenbone.net/browse/GEA-1197


