### PR TITLE
Remove delete_agent_installer command

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -845,7 +845,6 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
 #if ENABLE_AGENTS
   ELSE (create_agent_group)
   ELSE (delete_agent_group)
-  ELSE (delete_agent_installer)
 #endif
   ELSE (delete_asset)
   ELSE (delete_alert)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -17955,25 +17955,6 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
 }
 
 /**
- * @brief Delete an agent installer.
- *
- * @param[in]  connection      Connection to manager.
- * @param[in]  credentials     Credentials for authentication.
- * @param[in]  params          Request parameters.
- * @param[out] response_data   Extra data for the HTTP response.
- *
- * @return Enveloped XML object.
- */
-char *
-delete_agent_installer_gmp (gvm_connection_t *connection,
-                            credentials_t *credentials, params_t *params,
-                            cmd_response_data_t *response_data)
-{
-  return move_resource_to_trash (connection, "agent_installer", credentials,
-                                 params, response_data);
-}
-
-/**
  * @brief Get one agent, envelope the result.
  *
  * @param[in]  connection      Connection to manager.

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -833,10 +833,6 @@ get_agent_installer_file_gmp (gvm_connection_t *, credentials_t *, params_t *,
                               cmd_response_data_t *);
 
 char *
-delete_agent_installer_gmp (gvm_connection_t *, credentials_t *, params_t *,
-                            cmd_response_data_t *);
-
-char *
 get_agent_gmp (gvm_connection_t *, credentials_t *, params_t *,
                cmd_response_data_t *);
 

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -67,7 +67,6 @@ init_validator ()
                      "|(cvss_calculator)"
                      "|(delete_agent_list)"
                      "|(delete_agent_group)"
-                     "|(delete_agent_installer)"
                      "|(delete_asset)"
                      "|(delete_config)"
                      "|(delete_credential)"


### PR DESCRIPTION
## What
The delete_agent_installer command is removed.

## Why
The command is removed from gvmd / GMP so it should be removed here as well.

## References
GEA-1224
greenbone/gvmd/pull/2516
