### PR TITLE
Allow to build arbitrary container images

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,7 +1,10 @@
 ARG GVM_LIBS_VERSION=stable
 ARG DEBIAN_FRONTEND=noninteractive
+ARG FEATURE_TOGGLE=""
 
 FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION} AS build
+
+ARG FEATURE_TOGGLE
 
 COPY . /source
 WORKDIR /source
@@ -9,7 +12,7 @@ WORKDIR /source
 RUN sh /source/.github/install-dependencies.sh \
     /source/.github/build-dependencies.list \
     && rm -rf /var/lib/apt/lists/*
-RUN cmake -DCMAKE_BUILD_TYPE=Release -B /build /source \
+RUN cmake -DCMAKE_BUILD_TYPE=Release ${FEATURE_TOGGLE} -B /build /source \
     && DESTDIR=/install cmake --build /build -j$(nproc) -- install
 
 FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,10 +2,13 @@ name: Build and Push Container Images
 
 on:
   push:
-    branches: [main]
-    tags: ["v*"]
+    branches:
+      - main
+    tags:
+      - "v*"
   pull_request:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       ref-name:
@@ -13,17 +16,55 @@ on:
         description: "The ref to build a container image from. For example a tag v23.0.0."
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.ref-name || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: github.repository == 'greenbone/gsad'
-    name: Build and Push to Greenbone Registry
-    uses: greenbone/workflows/.github/workflows/container-build-push-2nd-gen.yml@main
+    if: ${{ github.repository == 'greenbone/gsad' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build:
+              name: default
+          - build:
+              name: agents
+              prefix: agents
+              build-args: "FEATURE_TOGGLE=-DENABLE_AGENTS=1"
+    name: Build and Push Container Images (${{ matrix.build.name }})
+    uses: greenbone/workflows/.github/workflows/container-build-push-gea.yml@main
     with:
-      base-image-label: stable
-      build-args: GVM_LIBS_VERSION=stable
-      image-url: community/gsad
-      image-labels: |
-        org.opencontainers.image.vendor=Greenbone
-        org.opencontainers.image.base.name=greenbone/gvm-libs
+      ref: ${{ inputs.ref-name }}
       ref-name: ${{ inputs.ref-name }}
+      name: ${{ matrix.build.name }}
+      build-args: ${{ matrix.build.build-args }}
+      prefix: ${{ matrix.build.prefix }}
+      images: |
+        ghcr.io/${{ github.repository }},enable=true
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
     secrets: inherit
+
+  notify:
+    needs:
+      - build
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'greenbone/gsad' }}
+    uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
+    with:
+      status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+    secrets: inherit
+
+  trigger-replication:
+    needs:
+      - build
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'greenbone/gsad' }}
+    runs-on: self-hosted-generic
+    steps:
+      - name: Ensure all tags are replicated on the public registry
+        uses: greenbone/actions/trigger-harbor-replication@v3
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ${{ vars.GREENBONE_REGISTRY }}
+          token: ${{ secrets.GREENBONE_REGISTRY_REPLICATION_TOKEN }}
+          user: ${{ secrets.GREENBONE_REGISTRY_REPLICATION_USER }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,15 @@ message(STATUS "Building gsad version ${GSAD_VERSION}")
 
 if(NOT ENABLE_AGENTS)
   set(ENABLE_AGENTS 0)
+else(NOT ENABLE_AGENTS)
+  message(STATUS "Building with agents feature enabled")
 endif(NOT ENABLE_AGENTS)
 add_definitions(-DENABLE_AGENTS=${ENABLE_AGENTS})
 
 if(NOT ENABLE_CONTAINER_SCANNING)
   set(ENABLE_CONTAINER_SCANNING 0)
+else(NOT ENABLE_CONTAINER_SCANNING)
+  message(STATUS "Building with container image scanning feature enabled")
 endif(NOT ENABLE_CONTAINER_SCANNING)
 add_definitions(-DENABLE_CONTAINER_SCANNING=${ENABLE_CONTAINER_SCANNING})
 


### PR DESCRIPTION


## What
Allow to build arbitrary container images

## Why

Enable to build container images with different feature sets enabled. Currently the agents feature set gets uploaded into a specific container image. The agents container images get pushed to to gchr.io only.

This PR also creates container images for every PR and uploads them to ghcr.io.

## References
https://jira.greenbone.net/browse/GEA-1139


