### PR TITLE
Fix: missing agent_group in resource_type validation

### DIFF
--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -498,12 +498,11 @@ init_validator ()
   gvm_validator_add (validator, "port_range_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (
     validator, "resource_type",
-    "^(agent|alert|asset|audit_report|audit|cert_bund_adv|config|cpe|"
-    "credential|"
-    "cve|dfn_cert_adv|filter|group|host|info|nvt|note|oci_image_target|os|"
-    "ovaldef|override|permission|policy|port_list|report|report_config|"
-    "report_format|result|role|scanner|schedule|tag|target|task|ticket|"
-    "tls_certificate|user|vuln|)$");
+    "^(agent|agent_group|alert|asset|audit_report|audit|cert_bund_adv|config|"
+    "cpe|credential|cve|dfn_cert_adv|filter|group|host|info|nvt|note|"
+    "oci_image_target|os|ovaldef|override|permission|policy|port_list|report|"
+    "report_config|report_format|result|role|scanner|schedule|tag|target|task|"
+    "ticket|tls_certificate|user|vuln|)$");
   gvm_validator_add (validator, "resource_id", "^[[:alnum:]\\-_.:\\/~]*$");
   gvm_validator_add (validator, "resources_action", "^(|add|set|remove)$");
   gvm_validator_add (


### PR DESCRIPTION
## What

Added agent_group to the list of supported values in resource_type validation.

## Why

agent_group was missing from the validation, which caused requests using this resource type to fail.

## References

GEA-1278

