### PR TITLE
fix: Fix NULL xml passed to gsad_envelope in login

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20852,8 +20852,10 @@ login (gsad_http_connection_t *con, params_t *params,
 
           credentials = gsad_credentials_new (user, language);
 
-          gchar *data =
-            envelope_gmp (NULL, credentials, params, NULL, response_data);
+          // xml must not be NULL: gsad_envelope() expects a valid string
+          // and passing NULL would trigger a GLib critical
+          gchar *data = envelope_gmp (NULL, credentials, params, g_strdup (""),
+                                      response_data);
 
           ret = gsad_http_create_response (con, data, response_data,
                                            gsad_user_get_cookie (user));

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20854,8 +20854,8 @@ login (gsad_http_connection_t *con, params_t *params,
 
           // xml must not be NULL: gsad_envelope() expects a valid string
           // and passing NULL would trigger a GLib critical
-          gchar *data = envelope_gmp (NULL, credentials, params, g_strdup (""),
-                                      response_data);
+          gchar *data =
+            gsad_envelope (credentials, g_strdup (""), response_data);
 
           ret = gsad_http_create_response (con, data, response_data,
                                            gsad_user_get_cookie (user));


### PR DESCRIPTION

## What

Fix passing `NULL` as XML payload to `gsad_envelope` in the login flow.


## Why

The `login` flow passed `NULL` as the XML payload to `gsad_envelope()`, which
resulted in a GLib critical (`g_string_append` does not accept `NULL`).

## References

https://github.com/greenbone/gsad/pull/369



