### PR TITLE
add: Add GSAD wrapper for GET_REPORT_TLS_CERTIFICATES

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1005,6 +1005,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_report)
   ELSE (get_report_hosts)
   ELSE (get_report_ports)
+  ELSE (get_report_tls_certificates)
   ELSE (get_reports)
   ELSE (get_report_config)
   ELSE (get_report_configs)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -9760,6 +9760,102 @@ get_report_ports_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Get report TLS certificates and return the result.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Username and password for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data return for the HTTP response.
+ *
+ * @return Report TLS certificates XML.
+ */
+char *
+get_report_tls_certificates_gmp (gvm_connection_t *connection,
+                                 gsad_credentials_t *credentials,
+                                 params_t *params,
+                                 cmd_response_data_t *response_data)
+{
+  GString *xml;
+  entity_t entity;
+  const char *report_id;
+  const char *filter;
+  const char *filter_id;
+  gboolean details, ignore_pagination;
+  int ret;
+
+  details = params_value_bool (params, "details");
+  ignore_pagination = params_value_bool (params, "ignore_pagination");
+
+  report_id = params_value (params, "report_id");
+  filter = params_value (params, "filter");
+  filter_id = params_value (params, "filter_id");
+
+  CHECK_VARIABLE_INVALID (report_id, "Get Report TLS Certificates");
+
+  if (filter == NULL || filter_id)
+    filter = "";
+
+  ret = gvm_connection_sendf_xml (connection,
+                                  "<get_report_tls_certificates"
+                                  " report_id=\"%s\""
+                                  " details=\"%d\""
+                                  " ignore_pagination=\"%d\""
+                                  " filter=\"%s\""
+                                  " filt_id=\"%s\"/>",
+                                  report_id, details, ignore_pagination, filter,
+                                  filter_id ? filter_id : FILT_ID_NONE);
+
+  if (ret == -1)
+    {
+      cmd_response_data_set_status_code (response_data,
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_message (
+        credentials, "Internal error", __func__, __LINE__,
+        "An internal error occurred while getting report TLS certificates. "
+        "The report TLS certificates could not be delivered. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
+
+  xml = g_string_new ("<get_report_tls_certificates>");
+
+  entity = NULL;
+  if (read_entity_and_string_c (connection, &entity, &xml))
+    {
+      cmd_response_data_set_status_code (response_data,
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_message (
+        credentials, "Internal error", __func__, __LINE__,
+        "An internal error occurred while getting report TLS certificates. "
+        "The report TLS certificates could not be delivered. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
+
+  if (gmp_success (entity) != 1)
+    {
+      gchar *message;
+
+      set_http_status_from_entity (entity, response_data);
+
+      message =
+        gsad_message (credentials, "Error", __func__, __LINE__,
+                      entity_attribute (entity, "status_text"), response_data);
+
+      g_string_free (xml, TRUE);
+      free_entity (entity);
+      return message;
+    }
+
+  free_entity (entity);
+
+  g_string_append (xml, "</get_report_tls_certificates>");
+
+  return envelope_gmp (connection, credentials, params,
+                       g_string_free (xml, FALSE), response_data);
+}
+
+/**
  * @brief Run alert for a report.
  *
  * @param[in]  connection     Connection to manager.

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -83,6 +83,9 @@ char *
 get_report_ports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                       cmd_response_data_t *);
 char *
+get_report_tls_certificates_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                 params_t *, cmd_response_data_t *);
+char *
 get_reports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                  cmd_response_data_t *);
 

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -176,6 +176,7 @@ gsad_init_validator ()
                      "|(get_report)"
                      "|(get_report_hosts)"
                      "|(get_report_ports)"
+                     "|(get_report_tls_certificates)"
                      "|(get_reports)"
                      "|(get_report_config)"
                      "|(get_report_configs)"


### PR DESCRIPTION
## What

Add a GSAD handler to fetch report tls certificates via GMP and return the XML response.

## Why

To enable retrieving report tls certificates data through the GSAD API for clients.

## References

GEA-1692


