### PR TITLE
Add JWT to credentials and remove language from it

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -181,7 +181,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gsad_user_t *user;
   gsad_credentials_t *credentials = NULL;
   gchar *res = NULL, *new_sid = NULL;
-  const gchar *cmd, *caller, *language;
+  const gchar *cmd, *caller;
   gvm_connection_t connection;
   cmd_response_data_t *response_data = cmd_response_data_new ();
 
@@ -277,9 +277,6 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   /* The caller of a POST is usually the caller of the page that the POST form
    * was on. */
-  language =
-    gsad_user_get_language (user) ?: gsad_connection_info_get_language (con_info) ?: DEFAULT_GSAD_LANGUAGE;
-
   credentials = gsad_credentials_new ();
   gsad_credentials_set_user (credentials, user);
   gsad_credentials_set_jwt (credentials, gsad_user_get_jwt (user));

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -280,7 +280,9 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   language =
     gsad_user_get_language (user) ?: gsad_connection_info_get_language (con_info) ?: DEFAULT_GSAD_LANGUAGE;
 
-  credentials = gsad_credentials_new (user, language);
+  credentials = gsad_credentials_new ();
+  gsad_credentials_set_user (credentials, user);
+  gsad_credentials_set_jwt (credentials, gsad_user_get_jwt (user));
 
   new_sid = g_strdup (gsad_user_get_cookie (user));
 

--- a/src/gsad_credentials.c
+++ b/src/gsad_credentials.c
@@ -19,26 +19,23 @@
  */
 struct gsad_credentials
 {
-  gchar *language;   ///< Language for this request
-  gsad_user_t *user; ///< Current user
+  gsad_user_t *user; ///< Current user, if available
+  gchar *jwt;        ///< JWT for this credential, if applicable
 };
 
 /**
- * @brief Create a new credential from user and language
- *
- * @param[in] user     User to set for the credential
- * @param[in] language Language to use for the credential
+ * @brief Create a new credential
  *
  * @return A new credential instance. The caller is responsible for freeing it
  */
 gsad_credentials_t *
-gsad_credentials_new (gsad_user_t *user, const gchar *language)
+gsad_credentials_new ()
 {
   gsad_credentials_t *credentials;
 
   credentials = g_malloc0 (sizeof (gsad_credentials_t));
-  credentials->user = gsad_user_copy (user);
-  credentials->language = g_strdup (language);
+  credentials->user = NULL;
+  credentials->jwt = NULL;
 
   return credentials;
 }
@@ -54,11 +51,26 @@ gsad_credentials_free (gsad_credentials_t *creds)
   if (!creds)
     return;
 
-  g_free (creds->language);
+  g_free (creds->jwt);
 
   gsad_user_free (creds->user);
 
   g_free (creds);
+}
+
+/**
+ * @brief Set the user for the credential
+ *
+ * @param[in] creds Credential to set the user for
+ * @param[in] user User to associate with the credential. The credential will
+ * make a copy of the user, so the caller retains ownership of the user object
+ * and is responsible for freeing it.
+ */
+void
+gsad_credentials_set_user (gsad_credentials_t *creds, gsad_user_t *user)
+{
+  gsad_user_free (creds->user);
+  creds->user = gsad_user_copy (user);
 }
 
 /**
@@ -76,15 +88,30 @@ gsad_credentials_get_user (gsad_credentials_t *cred)
 }
 
 /**
- * @brief Get the language associated with the credential
+ * @brief Set the JWT for the credential
  *
- * @param[in] cred Credential to get the language from
+ * @param[in] creds Credential to set the JWT for
+ * @param[in] jwt JWT to associate with the credential. The
+ * credential will make a copy of the JWT string, so the caller retains
+ * ownership of the string and is responsible for freeing it.
+ */
+void
+gsad_credentials_set_jwt (gsad_credentials_t *creds, const gchar *jwt_token)
+{
+  g_free (creds->jwt);
+  creds->jwt = g_strdup (jwt_token);
+}
+
+/**
+ * @brief Get the JWT associated with the credential
  *
- * @return The language associated with the credential. The caller should not
+ * @param[in] cred Credential to get the JWT from
+ *
+ * @return The JWT associated with the credential. The caller should not
  * free this string, as it is owned by the credential.
  */
 const gchar *
-gsad_credentials_get_language (gsad_credentials_t *cred)
+gsad_credentials_get_jwt (gsad_credentials_t *cred)
 {
-  return cred->language;
+  return cred->jwt;
 }

--- a/src/gsad_credentials.h
+++ b/src/gsad_credentials.h
@@ -18,15 +18,21 @@
 typedef struct gsad_credentials gsad_credentials_t;
 
 gsad_credentials_t *
-gsad_credentials_new (gsad_user_t *user, const gchar *language);
+gsad_credentials_new (void);
 
 void
 gsad_credentials_free (gsad_credentials_t *creds);
 
+void
+gsad_credentials_set_user (gsad_credentials_t *creds, gsad_user_t *user);
+
 gsad_user_t *
 gsad_credentials_get_user (gsad_credentials_t *creds);
 
+void
+gsad_credentials_set_jwt (gsad_credentials_t *creds, const gchar *jwt_token);
+
 const gchar *
-gsad_credentials_get_language (gsad_credentials_t *creds);
+gsad_credentials_get_jwt (gsad_credentials_t *creds);
 
 #endif /* _GSAD_CREDENTIALS_H */

--- a/src/gsad_credentials_tests.c
+++ b/src/gsad_credentials_tests.c
@@ -20,30 +20,63 @@ AfterEach (gsad_credentials)
 
 Ensure (gsad_credentials, should_allow_to_create_new_credential)
 {
-  gsad_user_t *user = gsad_user_new_with_data ("test_user", "test_token", "utc",
-                                               "", "en", "", "123");
-  gsad_credentials_t *credentials = gsad_credentials_new (user, "en");
-  gsad_user_t *cred_user = gsad_credentials_get_user (credentials);
+  gsad_credentials_t *credentials = gsad_credentials_new ();
 
   assert_that (credentials, is_not_null);
-  assert_that (cred_user, is_not_equal_to (user)); // Ensure a copy is made
-  assert_that (gsad_user_get_username (cred_user),
-               is_equal_to_string ("test_user"));
-  assert_that (gsad_user_get_token (cred_user),
-               is_equal_to_string (gsad_user_get_token (user)));
-  assert_that (gsad_user_get_timezone (cred_user), is_equal_to_string ("utc"));
-  assert_that (gsad_user_get_language (cred_user), is_equal_to_string ("en"));
-  assert_that (gsad_user_get_jwt (cred_user), is_equal_to_string ("123"));
-  assert_that (gsad_credentials_get_language (credentials),
-               is_equal_to_string ("en"));
-
+  assert_that (gsad_credentials_get_user (credentials), is_null);
+  assert_that (gsad_credentials_get_jwt (credentials), is_null);
   gsad_credentials_free (credentials);
-  gsad_user_free (user);
 }
 
 Ensure (gsad_credentials, should_allow_to_free_null_credential)
 {
   gsad_credentials_free (NULL);
+}
+
+Ensure (gsad_credentials, should_allow_to_set_user)
+{
+  gsad_credentials_t *credentials = gsad_credentials_new ();
+  gsad_user_t *user = gsad_user_new_with_data (
+    "testuser", "testpassword", "UTC", "capabilities", "en", "address", "jwt");
+
+  assert_that (credentials, is_not_null);
+  assert_that (gsad_credentials_get_user (credentials), is_null);
+
+  gsad_credentials_set_user (credentials, user);
+
+  // ensure a copy of the user is stored in credentials, not the same pointer
+  assert_that (gsad_credentials_get_user (credentials), is_not_equal_to (user));
+  gsad_user_t *stored_user = gsad_credentials_get_user (credentials);
+  assert_that (gsad_user_get_username (stored_user),
+               is_equal_to_string ("testuser"));
+  assert_that (gsad_user_get_password (stored_user),
+               is_equal_to_string ("testpassword"));
+  assert_that (gsad_user_get_timezone (stored_user),
+               is_equal_to_string ("UTC"));
+  assert_that (gsad_user_get_capabilities (stored_user),
+               is_equal_to_string ("capabilities"));
+  assert_that (gsad_user_get_language (stored_user), is_equal_to_string ("en"));
+  assert_that (gsad_user_get_client_address (stored_user),
+               is_equal_to_string ("address"));
+  assert_that (gsad_user_get_jwt (stored_user), is_equal_to_string ("jwt"));
+
+  gsad_credentials_free (credentials);
+  gsad_user_free (user);
+}
+
+Ensure (gsad_credentials, should_allow_to_set_jwt)
+{
+  gsad_credentials_t *credentials = gsad_credentials_new ();
+
+  assert_that (credentials, is_not_null);
+  assert_that (gsad_credentials_get_jwt (credentials), is_null);
+
+  gsad_credentials_set_jwt (credentials, "jwt");
+
+  assert_that (gsad_credentials_get_jwt (credentials),
+               is_equal_to_string ("jwt"));
+
+  gsad_credentials_free (credentials);
 }
 
 int
@@ -55,6 +88,8 @@ main (int argc, char **argv)
                          should_allow_to_create_new_credential);
   add_test_with_context (suite, gsad_credentials,
                          should_allow_to_free_null_credential);
+  add_test_with_context (suite, gsad_credentials, should_allow_to_set_user);
+  add_test_with_context (suite, gsad_credentials, should_allow_to_set_jwt);
 
   int ret = run_test_suite (suite, create_text_reporter ());
   destroy_test_suite (suite);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20992,7 +20992,7 @@ login (gsad_http_connection_t *con, params_t *params,
   gchar *timezone;
   gchar *capabilities;
   gchar *language;
-  gchar *jwt;
+  gchar *jwt = NULL;
 
   const char *password = params_value (params, "password");
   const char *login = params_value (params, "login");
@@ -21054,7 +21054,9 @@ login (gsad_http_connection_t *con, params_t *params,
           g_message ("Authentication success for '%s' from %s", login ?: "",
                      client_address);
 
-          credentials = gsad_credentials_new (user, language);
+          credentials = gsad_credentials_new ();
+          gsad_credentials_set_user (credentials, user);
+          gsad_credentials_set_jwt (credentials, jwt);
 
           // xml must not be NULL: gsad_envelope() expects a valid string
           // and passing NULL would trigger a GLib critical

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -2,7 +2,11 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-#include "gsad_gmp.h" /* for manager_connect */
+
+#include "gsad_http_handler_functions.h"
+
+#include "gsad_credentials.h" /* for gsad_credentials_t and related functions */
+#include "gsad_gmp.h"         /* for manager_connect */
 #include "gsad_http_handler.h"
 #include "gsad_i18n.h"       /* for accept_language_to_env_fmt */
 #include "gsad_manager.h"    /* for gsad_manager_connect_with_credentials */
@@ -330,11 +334,19 @@ gsad_http_handle_setup_credentials (gsad_http_handler_t *handler_next,
           return MHD_YES;
         }
       language = accept_language_to_env_fmt (accept_language);
-      credentials = gsad_credentials_new (user, language);
+      credentials = gsad_credentials_new ();
+      const gchar *jwt_token = user ? gsad_user_get_jwt (user) : NULL;
+
+      gsad_credentials_set_user (credentials, user);
+      gsad_credentials_set_jwt (credentials, jwt_token);
     }
   else
     {
-      credentials = gsad_credentials_new (user, language);
+      credentials = gsad_credentials_new ();
+      const gchar *jwt_token = user ? gsad_user_get_jwt (user) : NULL;
+
+      gsad_credentials_set_user (credentials, user);
+      gsad_credentials_set_jwt (credentials, jwt_token);
     }
 
   gsad_user_free (user);

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -312,45 +312,12 @@ gsad_http_handle_setup_credentials (gsad_http_handler_t *handler_next,
                                     void *data)
 {
   gsad_user_t *user = (gsad_user_t *) data;
-  const gchar *accept_language;
-  gsad_credentials_t *credentials;
-  char client_address[INET6_ADDRSTRLEN];
+  gsad_credentials_t *credentials = gsad_credentials_new ();
+  const gchar *jwt_token = user ? gsad_user_get_jwt (user) : NULL;
 
-  get_client_address (connection, client_address);
-
-  gchar *language = g_strdup (gsad_user_get_language (user));
-
-  if (!language)
-    /* Accept-Language: de; q=1.0, en; q=0.5 */
-    {
-      accept_language = MHD_lookup_connection_value (
-        connection, MHD_HEADER_KIND, "Accept-Language");
-      if (accept_language
-          && g_utf8_validate (accept_language, -1, NULL) == FALSE)
-        {
-          gsad_http_send_response_for_content (
-            connection, UTF8_ERROR_PAGE ("'Accept-Language' header"),
-            MHD_HTTP_BAD_REQUEST, NULL, GSAD_CONTENT_TYPE_TEXT_HTML, NULL, 0);
-          return MHD_YES;
-        }
-      language = accept_language_to_env_fmt (accept_language);
-      credentials = gsad_credentials_new ();
-      const gchar *jwt_token = user ? gsad_user_get_jwt (user) : NULL;
-
-      gsad_credentials_set_user (credentials, user);
-      gsad_credentials_set_jwt (credentials, jwt_token);
-    }
-  else
-    {
-      credentials = gsad_credentials_new ();
-      const gchar *jwt_token = user ? gsad_user_get_jwt (user) : NULL;
-
-      gsad_credentials_set_user (credentials, user);
-      gsad_credentials_set_jwt (credentials, jwt_token);
-    }
-
+  gsad_credentials_set_user (credentials, user);
+  gsad_credentials_set_jwt (credentials, jwt_token);
   gsad_user_free (user);
-  g_free (language);
 
   return gsad_http_handler_call (handler_next, connection, con_info,
                                  credentials);

--- a/src/gsad_manager.c
+++ b/src/gsad_manager.c
@@ -89,7 +89,7 @@ gmp_authenticate_with_xml (gvm_connection_t *connection, const gchar *xml)
 static int
 gmp_authenticate_with_jwt (gvm_connection_t *connection, const gchar *token)
 {
-  const gchar *xml = g_markup_printf_escaped ("<token>%s</token>", token);
+  gchar *xml = g_markup_printf_escaped ("<token>%s</token>", token);
   int ret = gmp_authenticate_with_xml (connection, xml);
   g_free (xml);
   return ret;
@@ -109,7 +109,7 @@ gmp_authenticate_with_username_password (gvm_connection_t *connection,
                                          const gchar *username,
                                          const gchar *password)
 {
-  const gchar *xml = g_markup_printf_escaped (
+  gchar *xml = g_markup_printf_escaped (
     "<username>%s</username><password>%s</password>", username, password);
   int ret = gmp_authenticate_with_xml (connection, xml);
   g_free (xml);


### PR DESCRIPTION
## What

Add JWT to credentials and remove language from it

## Why

JWT will be set from the authorization header in future and language is not used.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


