### PR TITLE
Change gsad_user_session_add to expect a user instead of creating one

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,6 +247,13 @@ if(BUILD_TESTING)
   )
   add_unit_test(gsad-user gsad_utils.c)
   add_unit_test(gsad-session gsad_user.c gsad_utils.c)
+  add_unit_test(
+    gsad-user-session
+    gsad_session.c
+    gsad_utils.c
+    gsad_settings.c
+    gsad_user.c
+  )
   add_custom_target(
     tests
     DEPENDS
@@ -262,6 +269,7 @@ if(BUILD_TESTING)
       gsad-credentials-test
       gsad-user-test
       gsad-session-test
+      gsad-user-session-test
   )
 endif(BUILD_TESTING)
 

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -348,7 +348,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     }
 
   /* always renew session for http post */
-  gsad_session_renew_user (gsad_user_get_token (user));
+  gsad_user_session_renew_timeout (user);
+  gsad_session_add_user (gsad_user_get_token (user), user);
 
   /* Handle the usual commands. */
   if (0)

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -349,7 +349,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   /* always renew session for http post */
   gsad_user_session_renew_timeout (user);
-  gsad_session_add_user (gsad_user_get_token (user), user);
+  gsad_session_replace_user_if_exists (gsad_user_get_token (user), user);
 
   /* Handle the usual commands. */
   if (0)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -21030,11 +21030,12 @@ login (gsad_http_connection_t *con, params_t *params,
         }
       else
         {
-          gsad_user_t *user;
-          user = gsad_user_session_add (login, password, timezone, capabilities,
-                                        language, client_address, jwt);
+          gsad_user_t *user =
+            gsad_user_new_with_data (login, password, timezone, capabilities,
+                                     language, client_address, jwt);
 
-          if (user == NULL)
+          int add_user = gsad_user_session_add (user);
+          if (add_user)
             {
               status = MHD_HTTP_FORBIDDEN;
               auth_reason = TOO_MANY_USER_SESSIONS;

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20212,7 +20212,9 @@ renew_session_gmp (gvm_connection_t *connection,
   gchar *html;
   gchar *message;
   gsad_user_t *user = gsad_credentials_get_user (credentials);
-  gsad_session_renew_user (gsad_user_get_token (user));
+
+  gsad_user_session_renew_timeout (user);
+  gsad_session_add_user (gsad_user_get_token (user), user);
 
   message = g_strdup_printf ("%ld", gsad_user_session_get_timeout (user));
 

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -14233,7 +14233,7 @@ save_my_settings_gmp (gvm_connection_t *connection,
 
   if (user_changed)
     {
-      gsad_session_add_user (gsad_user_get_token (user), user);
+      gsad_session_replace_user_if_exists (gsad_user_get_token (user), user);
     }
 
   return envelope_gmp (connection, credentials, params,
@@ -19247,7 +19247,7 @@ change_password_gmp (gvm_connection_t *connection,
       gsad_user_set_password (user, passwd);
       gsad_session_remove_other_sessions (gsad_user_get_token (user),
                                           gsad_user_get_username (user));
-      gsad_session_add_user (gsad_user_get_token (user), user);
+      gsad_session_replace_user_if_exists (gsad_user_get_token (user), user);
     }
 
   cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
@@ -20214,7 +20214,7 @@ renew_session_gmp (gvm_connection_t *connection,
   gsad_user_t *user = gsad_credentials_get_user (credentials);
 
   gsad_user_session_renew_timeout (user);
-  gsad_session_add_user (gsad_user_get_token (user), user);
+  gsad_session_replace_user_if_exists (gsad_user_get_token (user), user);
 
   message = g_strdup_printf ("%ld", gsad_user_session_get_timeout (user));
 

--- a/src/gsad_session.c
+++ b/src/gsad_session.c
@@ -264,22 +264,3 @@ gsad_session_remove_other_sessions (const gchar *keep_id, const gchar *username)
 
   g_mutex_unlock (mutex);
 }
-
-/**
- * @brief Update timestamp of given user to now
- *
- * @param[in] id  ID of the session
- */
-void
-gsad_session_renew_user (const gchar *id)
-{
-  g_mutex_lock (mutex);
-
-  gsad_user_t *user = gsad_session_get_user_by_id_internal (id);
-  if (user)
-    {
-      gsad_user_session_renew_timeout (user);
-    }
-
-  g_mutex_unlock (mutex);
-}

--- a/src/gsad_session.c
+++ b/src/gsad_session.c
@@ -76,8 +76,10 @@ gsad_session_get_user_by_id_internal (const gchar *id)
  * @brief Remove a user from the session "database" without locking the mutex.
  *
  * @param[in]  id  Unique identifier (token).
+ *
+ * @return TRUE if a user was removed, FALSE otherwise.
  */
-void
+gboolean
 gsad_session_remove_user_internal (const gchar *id)
 {
   gsad_user_t *user = gsad_session_get_user_by_id_internal (id);
@@ -86,8 +88,9 @@ gsad_session_remove_user_internal (const gchar *id)
     {
       // user is freed by the free function of the users array, so we only need
       // to remove it
-      g_ptr_array_remove (users, (gpointer) user);
+      return g_ptr_array_remove (users, (gpointer) user);
     }
+  return FALSE;
 }
 
 /**
@@ -191,6 +194,9 @@ gsad_session_get_users_by_username (const gchar *username)
 /**
  * @brief Add user to the session "database"
  *
+ * If a user with the same token already exists, it is removed before adding the
+ * new user.
+ *
  * @param[in]  id     Unique identifier (token).
  * @param[in]  user   User to add. The session will make a copy of the user, so
  * the caller retains ownership of the user object and is responsible for
@@ -212,6 +218,9 @@ gsad_session_add_user (const gchar *id, gsad_user_t *user)
 /**
  * @brief Remove a user from the session "database"
  *
+ * If the id is NULL or no user with the given id exists, this function does
+ * nothing.
+ *
  * @param[in]  id  Unique identifier.
  */
 void
@@ -220,6 +229,29 @@ gsad_session_remove_user (const gchar *id)
   g_mutex_lock (mutex);
 
   gsad_session_remove_user_internal (id);
+
+  g_mutex_unlock (mutex);
+}
+
+/**
+ * @brief Replace a user in the session "database" if it exists, otherwise the
+ * user is discarded and not added to the session.
+ *
+ * @param[in]  id     Unique identifier (token).
+ * @param[in]  user   User to add. The session will make a copy of the user, so
+ * the caller retains ownership of the user object and is responsible for
+ * freeing it. The session will free the user object when it is removed from the
+ * session.
+ */
+void
+gsad_session_replace_user_if_exists (const gchar *id, gsad_user_t *user)
+{
+  g_mutex_lock (mutex);
+
+  if (gsad_session_remove_user_internal (id))
+    {
+      gsad_session_add_user_internal (user);
+    }
 
   g_mutex_unlock (mutex);
 }

--- a/src/gsad_session.h
+++ b/src/gsad_session.h
@@ -19,6 +19,9 @@ void
 gsad_session_add_user (const gchar *id, gsad_user_t *user);
 
 void
+gsad_session_replace_user_if_exists (const gchar *id, gsad_user_t *user);
+
+void
 gsad_session_remove_user (const gchar *id);
 
 gsad_user_t *

--- a/src/gsad_session.h
+++ b/src/gsad_session.h
@@ -31,9 +31,6 @@ void
 gsad_session_remove_other_sessions (const gchar *id, const gchar *user);
 
 void
-gsad_session_renew_user (const gchar *id);
-
-void
 gsad_session_init (void);
 
 void

--- a/src/gsad_session_tests.c
+++ b/src/gsad_session_tests.c
@@ -208,6 +208,69 @@ Ensure (gsad_session, should_remove_other_sessions)
   gsad_user_free (user3);
 }
 
+Ensure (gsad_session, should_replace_user)
+{
+  gsad_user_t *user1 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user2 = gsad_user_copy (user1);
+  gsad_user_set_password (user2, "password2");
+
+  assert_string_equal (gsad_user_get_token (user1),
+                       gsad_user_get_token (user2));
+
+  gsad_session_add_user (gsad_user_get_token (user1), user1);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_session_replace_user_if_exists (gsad_user_get_token (user1), user2);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *retrieved_user =
+    gsad_session_get_user_by_id (gsad_user_get_token (user1));
+  assert_that (retrieved_user, is_not_null);
+  assert_that (gsad_user_get_password (retrieved_user),
+               is_equal_to_string ("password2"));
+
+  gsad_user_free (retrieved_user);
+  gsad_user_free (user1);
+  gsad_user_free (user2);
+}
+
+Ensure (gsad_session, should_not_replace_user_if_not_exists)
+{
+  gsad_user_t *user1 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user2 =
+    gsad_user_new_with_data ("username1", "password2", "timezone2",
+                             "capabilities2", "language2", "address2", "jwt2");
+
+  assert_string_not_equal (gsad_user_get_token (user1),
+                           gsad_user_get_token (user2));
+
+  gsad_session_replace_user_if_exists (gsad_user_get_token (user1), user1);
+  assert_that (gsad_session_get_user_count (), is_equal_to (0));
+
+  gsad_session_add_user (gsad_user_get_token (user1), user1);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_session_replace_user_if_exists (gsad_user_get_token (user2), user2);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *retrieved_user;
+  retrieved_user = gsad_session_get_user_by_id (gsad_user_get_token (user2));
+  assert_that (retrieved_user, is_null);
+
+  retrieved_user = gsad_session_get_user_by_id (gsad_user_get_token (user1));
+  assert_that (retrieved_user, is_not_null);
+  assert_that (gsad_user_get_password (retrieved_user),
+               is_equal_to_string ("password1"));
+
+  gsad_user_free (retrieved_user);
+  gsad_user_free (user1);
+  gsad_user_free (user2);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -232,6 +295,9 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_session,
                          should_allow_to_remove_user_with_null);
   add_test_with_context (suite, gsad_session, should_remove_other_sessions);
+  add_test_with_context (suite, gsad_session, should_replace_user);
+  add_test_with_context (suite, gsad_session,
+                         should_not_replace_user_if_not_exists);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());

--- a/src/gsad_session_tests.c
+++ b/src/gsad_session_tests.c
@@ -208,36 +208,6 @@ Ensure (gsad_session, should_remove_other_sessions)
   gsad_user_free (user3);
 }
 
-Ensure (gsad_session, should_renew_user)
-{
-  gsad_user_t *retrieved_user;
-
-  gsad_user_t *user =
-    gsad_user_new_with_data ("username1", "password1", "timezone1",
-                             "capabilities1", "language1", "address1", "jwt1");
-
-  const gchar *token = gsad_user_get_token (user);
-  time_t timeout = gsad_user_get_time (user);
-  gsad_session_add_user (token, user);
-
-  assert_that (gsad_session_get_user_count (), is_equal_to (1));
-  retrieved_user = gsad_session_get_user_by_id (token);
-  assert_that (gsad_user_get_time (retrieved_user), is_equal_to (timeout));
-  gsad_user_free (retrieved_user);
-
-  gsad_session_renew_user (token);
-
-  assert_that (gsad_session_get_user_count (), is_equal_to (1));
-  retrieved_user = gsad_session_get_user_by_id (token);
-  assert_that (gsad_user_get_time (retrieved_user), is_not_equal_to (timeout));
-  gsad_user_free (retrieved_user);
-  retrieved_user = gsad_session_get_user_by_id (token);
-  assert_that (gsad_user_get_time (retrieved_user), is_equal_to (0));
-  gsad_user_free (retrieved_user);
-
-  gsad_user_free (user);
-}
-
 int
 main (int argc, char **argv)
 {
@@ -262,7 +232,6 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_session,
                          should_allow_to_remove_user_with_null);
   add_test_with_context (suite, gsad_session, should_remove_other_sessions);
-  add_test_with_context (suite, gsad_session, should_renew_user);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());

--- a/src/gsad_user_session.c
+++ b/src/gsad_user_session.c
@@ -93,8 +93,7 @@ gsad_user_session_add (gsad_user_t *user)
 /**
  * @brief Find a user in the session, given a token and cookie.
  *
- * If a user is returned, the session of the user is renewed and it's up to the
- * caller to free the user.
+ * If a user is returned it's up to the caller to free the user.
  *
  * @param[in]   cookie       Token in cookie.
  * @param[in]   token        Token request parameter.
@@ -143,8 +142,6 @@ gsad_user_session_find (const gchar *cookie, const gchar *token,
         }
       else
         {
-          gsad_session_renew_user (user->token);
-
           *user_return = user;
           return USER_OK;
         }
@@ -171,7 +168,11 @@ gsad_user_session_get_timeout (gsad_user_t *user)
 }
 
 /**
- * @brief Renew a user's session by updating the login time to the current time.
+ * @brief Renew the session timeout by updating the login time to the current
+ * time.
+ *
+ * To make this change permanent, the user must be added again to the session
+ * store after calling this function.
  *
  * @param[in] user User whose session is to be renewed.
  */

--- a/src/gsad_user_session.c
+++ b/src/gsad_user_session.c
@@ -6,7 +6,7 @@
 #include "gsad_user_session.h"
 
 #include "gsad_gmp_auth.h" /* for logout_gmp */
-#include "gsad_session.h"
+#include "gsad_session.h" /* for gsad_session_get_user_by_id, gsad_session_remove_user, gsad_session_add_user, gsad_session_get_users_by_username */
 #include "gsad_settings.h" /* for gsad_settings_get_session_timeout  */
 #include "gsad_user_internal.h"
 #include "gsad_utils.h" /* for str_equal */
@@ -51,60 +51,43 @@ gsad_user_session_is_expired (gsad_user_t *user)
 /**
  * @brief Add a user to the session store.
  *
- * Creates and initializes a user object with given parameters
+ * @param[in]  user      User to add.
  *
- * It's up to the caller to free the returned user.
- *
- * @param[in]  username      Name of user.
- * @param[in]  password      Password for user.
- * @param[in]  timezone      Timezone of user.
- * @param[in]  capabilities  Capabilities of manager.
- * @param[in]  language      User Interface Language (language name or code)
- * @param[in]  address       Client's IP address.
- * @param[in]  jwt           JWT token value, NULL if not requested.
- *
- * @return Added user.
+ * @return 0 success, 1 if session limit exceeded
  */
-gsad_user_t *
-gsad_user_session_add (const gchar *username, const gchar *password,
-                       const gchar *timezone, const gchar *capabilities,
-                       const gchar *language, const char *address,
-                       const gchar *jwt)
+int
+gsad_user_session_add (gsad_user_t *user)
 {
   GList *current_user_item, *user_list;
-  gsad_user_t *user;
   int session_count = 0;
+  gsad_user_t *current_user = NULL;
 
-  user_list = current_user_item = gsad_session_get_users_by_username (username);
+  user_list = current_user_item =
+    gsad_session_get_users_by_username (gsad_user_get_username (user));
   while (current_user_item)
     {
-      user = current_user_item->data;
-      if (gsad_user_session_is_expired (user))
+      current_user = current_user_item->data;
+      if (gsad_user_session_is_expired (current_user))
         {
-          if (user->username && user->password)
-            logout_gmp (user->username, user->password);
-          gsad_session_remove_user (user->token);
+          if (current_user->username && current_user->password)
+            logout_gmp (current_user->username, current_user->password);
+          gsad_session_remove_user (current_user->token);
         }
       else
         session_count++;
-      gsad_user_free (user);
       current_user_item = current_user_item->next;
     }
-  g_list_free (user_list);
+  g_list_free_full (user_list, (GDestroyNotify) gsad_user_free);
 
   gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
   int session_limit =
     gsad_settings_get_user_session_limit (gsad_global_settings);
   if (session_limit && (session_count >= session_limit))
-
-    return NULL;
-
-  user = gsad_user_new_with_data (username, password, timezone, capabilities,
-                                  language, address, jwt);
+    return 1;
 
   gsad_session_add_user (user->token, user);
 
-  return user;
+  return 0;
 }
 
 /**

--- a/src/gsad_user_session.h
+++ b/src/gsad_user_session.h
@@ -20,11 +20,8 @@ int
 gsad_user_session_find (const gchar *cookie, const gchar *token,
                         const char *address, gsad_user_t **user_return);
 
-gsad_user_t *
-gsad_user_session_add (const gchar *username, const gchar *password,
-                       const gchar *timezone, const gchar *capabilities,
-                       const gchar *language, const char *address,
-                       const gchar *jwt);
+int
+gsad_user_session_add (gsad_user_t *user);
 
 gboolean
 gsad_user_session_is_expired (gsad_user_t *user);

--- a/src/gsad_user_session_tests.c
+++ b/src/gsad_user_session_tests.c
@@ -294,9 +294,14 @@ Ensure (
 
 Ensure (gsad_user_session, should_allow_to_find_user)
 {
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_settings_set_session_timeout (gsad_global_settings, 600);
   gsad_user_t *user =
     gsad_user_new_with_data ("username1", "password1", "timezone1",
                              "capabilities1", "language1", "address1", "jwt1");
+  // set the user time to 10 seconds ago to test
+  // that the session of the retrieved user is not renewed when found
+  user->time = user->time - 10;
   gsad_user_session_add (user);
   assert_that (gsad_session_get_user_count (), is_equal_to (1));
 
@@ -321,6 +326,8 @@ Ensure (gsad_user_session, should_allow_to_find_user)
   assert_that (gsad_user_get_client_address (user_return),
                is_equal_to_string ("address1"));
   assert_that (gsad_user_get_jwt (user_return), is_equal_to_string ("jwt1"));
+  assert_that (gsad_user_get_time (user_return),
+               is_equal_to (gsad_user_get_time (user)));
 
   gsad_user_free (user_return);
   gsad_user_free (user);

--- a/src/gsad_user_session_tests.c
+++ b/src/gsad_user_session_tests.c
@@ -1,0 +1,408 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "gsad_session.h"
+#include "gsad_session_internal.h"
+#include "gsad_settings.h"
+#include "gsad_user_internal.h"
+#include "gsad_user_session.h"
+
+#include <cgreen/cgreen.h>
+
+int
+logout_gmp (const gchar *username, const gchar *password)
+{
+  return 0;
+}
+
+Describe (gsad_user_session);
+BeforeEach (gsad_user_session)
+{
+  gsad_session_init ();
+}
+AfterEach (gsad_user_session)
+{
+  gsad_session_cleanup ();
+}
+
+Ensure (gsad_user_session, should_allow_to_add_user)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+
+  int ret = gsad_user_session_add (user);
+  assert_that (ret, is_equal_to (0));
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *retrieved_user = NULL;
+  ret = gsad_user_session_find (
+    gsad_user_get_cookie (user), gsad_user_get_token (user),
+    gsad_user_get_client_address (user), &retrieved_user);
+  assert_that (ret, is_equal_to (0));
+  assert_that (retrieved_user, is_not_null);
+  assert_that (retrieved_user, is_not_equal_to (user));
+  assert_that (gsad_user_get_username (retrieved_user),
+               is_equal_to_string ("username1"));
+  assert_that (gsad_user_get_password (retrieved_user),
+               is_equal_to_string ("password1"));
+  assert_that (gsad_user_get_timezone (retrieved_user),
+               is_equal_to_string ("timezone1"));
+  assert_that (gsad_user_get_capabilities (retrieved_user),
+               is_equal_to_string ("capabilities1"));
+  assert_that (gsad_user_get_language (retrieved_user),
+               is_equal_to_string ("language1"));
+  assert_that (gsad_user_get_client_address (retrieved_user),
+               is_equal_to_string ("address1"));
+  assert_that (gsad_user_get_jwt (retrieved_user), is_equal_to_string ("jwt1"));
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session,
+        should_not_allow_to_add_user_if_session_limit_exceeded)
+{
+  gsad_user_t *user1 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user2 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user3 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_settings_set_user_session_limit (gsad_global_settings, 2);
+
+  int ret = gsad_user_session_add (user1);
+  assert_that (ret, is_equal_to (0));
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  ret = gsad_user_session_add (user2);
+  assert_that (ret, is_equal_to (0));
+  assert_that (gsad_session_get_user_count (), is_equal_to (2));
+
+  ret = gsad_user_session_add (user3);
+  assert_that (ret, is_equal_to (1));
+  assert_that (gsad_session_get_user_count (), is_equal_to (2));
+
+  gsad_user_free (user1);
+  gsad_user_free (user2);
+  gsad_user_free (user3);
+}
+
+Ensure (gsad_user_session, should_remove_expired_sessions)
+{
+  gsad_user_t *user1 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user2 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user3 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+
+  int ret = gsad_user_session_add (user1);
+  assert_that (ret, is_equal_to (0));
+  ret = gsad_user_session_add (user2);
+  assert_that (ret, is_equal_to (0));
+  assert_that (gsad_session_get_user_count (), is_equal_to (2));
+
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_settings_set_session_timeout (gsad_global_settings, -10);
+
+  ret = gsad_user_session_add (user3);
+  assert_that (ret, is_equal_to (0));
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_free (user1);
+  gsad_user_free (user2);
+  gsad_user_free (user3);
+}
+
+Ensure (gsad_user_session, should_check_session_expiration)
+{
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+
+  gsad_settings_set_session_timeout (gsad_global_settings, 100);
+
+  assert_that (gsad_user_session_is_expired (user), is_false);
+
+  gsad_settings_set_session_timeout (gsad_global_settings, -10);
+
+  assert_that (gsad_user_session_is_expired (user), is_true);
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session, should_allow_to_renew_session_timeout)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  user->time = 0;
+  assert_equal (gsad_user_get_time (user), 0);
+
+  gsad_user_session_renew_timeout (user);
+
+  assert_that (gsad_user_get_time (user), is_not_equal_to (0));
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session, should_allow_to_get_the_timeout)
+{
+  int timeout_in_minutes = 10;
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_settings_set_session_timeout (gsad_global_settings, timeout_in_minutes);
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  user->time = 0;
+  assert_equal (gsad_user_get_time (user), 0);
+  assert_equal (gsad_user_session_get_timeout (user), timeout_in_minutes * 60);
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session,
+        should_return_bad_missing_token_for_user_find_without_token)
+{
+  gsad_user_t *user_return = NULL;
+  int ret = gsad_user_session_find ("cookie", NULL, "address", &user_return);
+  assert_that (ret, is_equal_to (USER_BAD_MISSING_TOKEN));
+  assert_that (user_return, is_null);
+}
+
+Ensure (gsad_user_session,
+        should_return_expired_token_for_user_find_with_unknown_token)
+{
+  gsad_user_t *user_return = NULL;
+  int ret =
+    gsad_user_session_find ("cookie", "unknown_token", "address", &user_return);
+  assert_that (ret, is_equal_to (USER_EXPIRED_TOKEN));
+  assert_that (user_return, is_null);
+}
+
+Ensure (gsad_user_session,
+        should_return_expired_token_for_user_find_expired_session)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_settings_set_session_timeout (gsad_global_settings, -10);
+
+  gsad_user_t *user_return = NULL;
+  int ret = gsad_user_session_find ("cookie", gsad_user_get_token (user),
+                                    "address", &user_return);
+  assert_that (gsad_session_get_user_count (), is_equal_to (0));
+  assert_that (ret, is_equal_to (USER_EXPIRED_TOKEN));
+  assert_that (user_return, is_null);
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session,
+        should_return_bad_missing_cookie_for_user_find_with_missing_cookie)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *user_return = NULL;
+  int ret = gsad_user_session_find (NULL, gsad_user_get_token (user), "address",
+                                    &user_return);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+  assert_that (ret, is_equal_to (USER_BAD_MISSING_COOKIE));
+  assert_that (user_return, is_null);
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session,
+        should_return_bad_missing_cookie_for_user_find_with_cookie_mismatch)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *user_return = NULL;
+  int ret = gsad_user_session_find (
+    "mismatched_cookie", gsad_user_get_token (user), "address", &user_return);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+  assert_that (ret, is_equal_to (USER_BAD_MISSING_COOKIE));
+  assert_that (user_return, is_null);
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session,
+        should_return_ip_address_missmatch_for_user_find_with_no_address)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *user_return = NULL;
+  int ret =
+    gsad_user_session_find (gsad_user_get_cookie (user),
+                            gsad_user_get_token (user), NULL, &user_return);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+  assert_that (ret, is_equal_to (USER_IP_ADDRESS_MISSMATCH));
+  assert_that (user_return, is_null);
+
+  gsad_user_free (user);
+}
+
+Ensure (
+  gsad_user_session,
+  should_return_ip_address_missmatch_for_user_find_with_ip_address_mismatch)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *user_return = NULL;
+  int ret = gsad_user_session_find (gsad_user_get_cookie (user),
+                                    gsad_user_get_token (user),
+                                    "mismatched_address", &user_return);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+  assert_that (ret, is_equal_to (USER_IP_ADDRESS_MISSMATCH));
+  assert_that (user_return, is_null);
+
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session, should_allow_to_find_user)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_t *user_return = NULL;
+  int ret = gsad_user_session_find (gsad_user_get_cookie (user),
+                                    gsad_user_get_token (user), "address1",
+                                    &user_return);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+  assert_that (ret, is_equal_to (USER_OK));
+  assert_that (user_return, is_not_null);
+
+  assert_that (gsad_user_get_username (user_return),
+               is_equal_to_string ("username1"));
+  assert_that (gsad_user_get_password (user_return),
+               is_equal_to_string ("password1"));
+  assert_that (gsad_user_get_timezone (user_return),
+               is_equal_to_string ("timezone1"));
+  assert_that (gsad_user_get_capabilities (user_return),
+               is_equal_to_string ("capabilities1"));
+  assert_that (gsad_user_get_language (user_return),
+               is_equal_to_string ("language1"));
+  assert_that (gsad_user_get_client_address (user_return),
+               is_equal_to_string ("address1"));
+  assert_that (gsad_user_get_jwt (user_return), is_equal_to_string ("jwt1"));
+
+  gsad_user_free (user_return);
+  gsad_user_free (user);
+}
+
+Ensure (gsad_user_session, should_allow_to_logout_with_unknown_user)
+{
+  gsad_user_t *user1 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_t *user2 =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+
+  gsad_user_session_add (user1);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_session_logout (user2);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_free (user1);
+  gsad_user_free (user2);
+}
+
+Ensure (gsad_user_session, should_allow_to_logout_user)
+{
+  gsad_user_t *user =
+    gsad_user_new_with_data ("username1", "password1", "timezone1",
+                             "capabilities1", "language1", "address1", "jwt1");
+  gsad_user_session_add (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (1));
+
+  gsad_user_session_logout (user);
+  assert_that (gsad_session_get_user_count (), is_equal_to (0));
+
+  gsad_user_free (user);
+}
+
+int
+main (int argc, char **argv)
+{
+  TestSuite *suite = create_test_suite ();
+
+  add_test_with_context (suite, gsad_user_session, should_allow_to_add_user);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_not_allow_to_add_user_if_session_limit_exceeded);
+  add_test_with_context (suite, gsad_user_session,
+                         should_remove_expired_sessions);
+  add_test_with_context (suite, gsad_user_session,
+                         should_check_session_expiration);
+  add_test_with_context (suite, gsad_user_session,
+                         should_allow_to_renew_session_timeout);
+  add_test_with_context (suite, gsad_user_session,
+                         should_allow_to_get_the_timeout);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_bad_missing_token_for_user_find_without_token);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_expired_token_for_user_find_with_unknown_token);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_expired_token_for_user_find_expired_session);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_bad_missing_cookie_for_user_find_with_missing_cookie);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_bad_missing_cookie_for_user_find_with_cookie_mismatch);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_ip_address_missmatch_for_user_find_with_no_address);
+  add_test_with_context (
+    suite, gsad_user_session,
+    should_return_ip_address_missmatch_for_user_find_with_ip_address_mismatch);
+  add_test_with_context (suite, gsad_user_session, should_allow_to_find_user);
+  add_test_with_context (suite, gsad_user_session,
+                         should_allow_to_logout_with_unknown_user);
+  add_test_with_context (suite, gsad_user_session, should_allow_to_logout_user);
+
+  int ret = run_test_suite (suite, create_text_reporter ());
+  destroy_test_suite (suite);
+  return ret;
+}


### PR DESCRIPTION


## What
Change gsad_user_session_add to expect a user instead of creating one
Change renewing the user session timeout.

## Why

Only create a new user within gsad_user module and not within gsad_user_session.
Only have one dedication way to extend the session timeout.

Also add tests to ensure the behavior of the gsad user session module.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


