### PR TITLE
Fix: leaks in tests

### DIFF
--- a/src/gsad_args_tests.c
+++ b/src/gsad_args_tests.c
@@ -1615,6 +1615,8 @@ Ensure (gsad_args, should_parse_jwt_requested_default)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_args, gsad_args_new);
@@ -1771,7 +1773,12 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, gsad_args, should_free_gsad_args);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_args_tests.c
+++ b/src/gsad_args_tests.c
@@ -37,7 +37,7 @@ Ensure (gsad_args, gsad_args_new)
 {
   gsad_args_t *args = gsad_args_new ();
 
-  const gchar *manager_unix_socket_default_path =
+  gchar *manager_unix_socket_default_path =
     g_build_filename (GVMD_RUN_DIR, "gvmd.sock", NULL);
 
   assert_that (args, is_not_null);
@@ -88,6 +88,7 @@ Ensure (gsad_args, gsad_args_new)
   assert_that (args->verbose, is_false);
 
   gsad_args_free (args);
+  g_free (manager_unix_socket_default_path);
 }
 
 Ensure (gsad_args, should_parse_api_only)
@@ -304,13 +305,15 @@ Ensure (gsad_args, should_parse_gsad_manager_unix_socket_path)
 Ensure (gsad_args, should_parse_gsad_manager_unix_socket_path_default)
 {
   gsad_args_t *args = gsad_args_new ();
-  const gchar *manager_unix_socket_default_path =
+  gchar *manager_unix_socket_default_path =
     g_build_filename (GVMD_RUN_DIR, "gvmd.sock", NULL);
   char *argv[] = {"gsad"};
   gsad_args_parse (1, argv, args);
 
   assert_that (gsad_args_get_manager_unix_socket_path (args),
                is_equal_to_string (manager_unix_socket_default_path));
+
+  g_free (manager_unix_socket_default_path);
   gsad_args_free (args);
 }
 
@@ -1266,8 +1269,9 @@ Ensure (gsad_args, should_get_listen_addresses)
 Ensure (gsad_args, should_get_manager_unix_socket_path)
 {
   gsad_args_t *args = gsad_args_new ();
-  const gchar *manager_unix_socket_default_path =
+  gchar *manager_unix_socket_default_path =
     g_build_filename (GVMD_RUN_DIR, "gvmd.sock", NULL);
+
   assert_that (gsad_args_get_manager_unix_socket_path (args),
                is_equal_to_string (manager_unix_socket_default_path));
 
@@ -1277,6 +1281,7 @@ Ensure (gsad_args, should_get_manager_unix_socket_path)
   args->manager_unix_socket_path = NULL;
   assert_that (gsad_args_get_manager_unix_socket_path (args), is_null);
 
+  g_free (manager_unix_socket_default_path);
   gsad_args_free (args);
 }
 

--- a/src/gsad_connection_info_tests.c
+++ b/src/gsad_connection_info_tests.c
@@ -125,7 +125,10 @@ Ensure (gsad_connection_info, should_set_and_get_language)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
+
   add_test_with_context (suite, gsad_connection_info,
                          should_allow_to_create_connection_info_for_post);
   add_test_with_context (suite, gsad_connection_info,
@@ -141,8 +144,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_connection_info,
                          should_allow_to_free_null_connection_info);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
 
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_credentials_tests.c
+++ b/src/gsad_credentials_tests.c
@@ -82,6 +82,8 @@ Ensure (gsad_credentials, should_allow_to_set_jwt)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_credentials,
@@ -91,7 +93,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_credentials, should_allow_to_set_user);
   add_test_with_context (suite, gsad_credentials, should_allow_to_set_jwt);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_http_handler_tests.c
+++ b/src/gsad_http_handler_tests.c
@@ -354,6 +354,7 @@ Ensure (gsad_http_handler, should_allow_to_add_handler_from_func)
 int
 main (int argc, char **argv)
 {
+  int ret;
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_http_handler,
@@ -378,7 +379,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_http_handler,
                          should_allow_to_add_handler_from_func);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_http_handler_tests.c
+++ b/src/gsad_http_handler_tests.c
@@ -29,7 +29,7 @@ BeforeEach (gsad_http_handler)
 
 AfterEach (gsad_http_handler)
 {
-  g_list_free (calls);
+  g_list_free_full (calls, g_free);
 }
 
 void

--- a/src/gsad_http_method_handler_tests.c
+++ b/src/gsad_http_method_handler_tests.c
@@ -30,7 +30,7 @@ BeforeEach (gsad_http_method_handler)
 
 AfterEach (gsad_http_method_handler)
 {
-  g_list_free (calls);
+  g_list_free_full (calls, g_free);
 }
 
 void

--- a/src/gsad_http_method_handler_tests.c
+++ b/src/gsad_http_method_handler_tests.c
@@ -206,6 +206,7 @@ Ensure (gsad_http_method_handler, should_call_get_handler_for_get_method)
   assert_that (call->con_info, is_equal_to (con_info));
   assert_that (call->data, is_null);
 
+  gsad_connection_info_free (con_info);
   gsad_http_handler_free (method_handler);
 }
 
@@ -230,6 +231,7 @@ Ensure (gsad_http_method_handler, should_call_post_handler_for_post_method)
   assert_that (call->con_info, is_equal_to (con_info));
   assert_that (call->data, is_null);
 
+  gsad_connection_info_free (con_info);
   gsad_http_handler_free (method_handler);
 }
 
@@ -247,6 +249,7 @@ Ensure (gsad_http_method_handler, should_not_call_handlers_for_other_methods)
   assert_that (result, is_equal_to (MHD_NO));
   assert_that (get_call_count (), is_equal_to (0));
 
+  gsad_connection_info_free (con_info);
   gsad_http_handler_free (method_handler);
 }
 
@@ -275,6 +278,7 @@ Ensure (gsad_http_method_handler, should_call_next_handler_for_other_methods)
   assert_that (call->con_info, is_equal_to (con_info));
   assert_that (call->data, is_null);
 
+  gsad_connection_info_free (con_info);
   gsad_http_handler_free (method_handler);
 }
 

--- a/src/gsad_http_method_handler_tests.c
+++ b/src/gsad_http_method_handler_tests.c
@@ -322,6 +322,8 @@ Ensure (gsad_http_method_handler, should_set_next_on_all_leaves)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_http_method_handler,
@@ -345,7 +347,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_http_method_handler,
                          should_set_next_on_all_leaves);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_http_method_handler_tests.c
+++ b/src/gsad_http_method_handler_tests.c
@@ -320,7 +320,7 @@ Ensure (gsad_http_method_handler, should_set_next_on_all_leaves)
   assert_that (post_handler1->next, is_equal_to (next_handler));
   assert_that (get_handler2->next, is_equal_to (next_handler));
 
-  gsad_http_handler_free (method_handler1);
+  gsad_http_handler_free (method_handler3);
 }
 
 int

--- a/src/gsad_http_url_handler_tests.c
+++ b/src/gsad_http_url_handler_tests.c
@@ -287,6 +287,8 @@ Ensure (gsad_http_url_handler, should_allow_to_free_chain_and_data)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_http_url_handler,
@@ -306,7 +308,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_http_url_handler,
                          should_allow_to_free_chain_and_data);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_params_mhd_tests.c
+++ b/src/gsad_params_mhd_tests.c
@@ -332,6 +332,8 @@ Ensure (gsad_params_mhd,
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_params_mhd,
@@ -370,7 +372,12 @@ main (int argc, char **argv)
     suite, gsad_params_mhd,
     should_handle_valueless_array_params_in_params_mhd_append);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_session_tests.c
+++ b/src/gsad_session_tests.c
@@ -237,6 +237,8 @@ Ensure (gsad_session, should_renew_user)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_session, should_add_and_get_user);
@@ -258,7 +260,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_session, should_remove_other_sessions);
   add_test_with_context (suite, gsad_session, should_renew_user);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_session_tests.c
+++ b/src/gsad_session_tests.c
@@ -210,6 +210,8 @@ Ensure (gsad_session, should_remove_other_sessions)
 
 Ensure (gsad_session, should_renew_user)
 {
+  gsad_user_t *retrieved_user;
+
   gsad_user_t *user =
     gsad_user_new_with_data ("username1", "password1", "timezone1",
                              "capabilities1", "language1", "address1", "jwt1");
@@ -218,20 +220,22 @@ Ensure (gsad_session, should_renew_user)
   time_t timeout = gsad_user_get_time (user);
   gsad_session_add_user (token, user);
 
-  gsad_user_t *retrieved_user = gsad_session_get_user_by_id (token);
   assert_that (gsad_session_get_user_count (), is_equal_to (1));
+  retrieved_user = gsad_session_get_user_by_id (token);
   assert_that (gsad_user_get_time (retrieved_user), is_equal_to (timeout));
+  gsad_user_free (retrieved_user);
 
   gsad_session_renew_user (token);
 
   assert_that (gsad_session_get_user_count (), is_equal_to (1));
-  assert_that (gsad_user_get_time (gsad_session_get_user_by_id (token)),
-               is_not_equal_to (timeout));
-  assert_that (gsad_user_get_time (gsad_session_get_user_by_id (token)),
-               is_equal_to (0));
+  retrieved_user = gsad_session_get_user_by_id (token);
+  assert_that (gsad_user_get_time (retrieved_user), is_not_equal_to (timeout));
+  gsad_user_free (retrieved_user);
+  retrieved_user = gsad_session_get_user_by_id (token);
+  assert_that (gsad_user_get_time (retrieved_user), is_equal_to (0));
+  gsad_user_free (retrieved_user);
 
   gsad_user_free (user);
-  gsad_user_free (retrieved_user);
 }
 
 int

--- a/src/gsad_settings_tests.c
+++ b/src/gsad_settings_tests.c
@@ -419,6 +419,8 @@ Ensure (gsad_settings, should_set_manager_address)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_settings, should_use_defaults);
@@ -452,8 +454,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_settings, should_set_jwt_requested);
   add_test_with_context (suite, gsad_settings, should_set_manager_address);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
 
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_user_tests.c
+++ b/src/gsad_user_tests.c
@@ -180,6 +180,8 @@ Ensure (gsad_user, should_set_username)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_user, should_create_new_user);
@@ -191,7 +193,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_user, should_set_language);
   add_test_with_context (suite, gsad_user, should_set_username);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_utils_tests.c
+++ b/src/gsad_utils_tests.c
@@ -43,6 +43,8 @@ Ensure (gsad_utils, null_or_value)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
 
   add_test_with_context (suite, gsad_utils,
@@ -51,7 +53,12 @@ main (int argc, char **argv)
                          credential_username_is_valid_failure);
   add_test_with_context (suite, gsad_utils, null_or_value);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -785,5 +785,6 @@ gsad_get_validator ()
 void
 gsad_reset_validator ()
 {
+  gvm_validator_free (validator);
   validator = NULL;
 }

--- a/src/gsad_validator_tests.c
+++ b/src/gsad_validator_tests.c
@@ -255,7 +255,10 @@ Ensure (gsad_validator, alias_hostpath_scanner_host)
 int
 main (int argc, char **argv)
 {
+  int ret;
+
   TestSuite *suite = create_test_suite ();
+
   add_test_with_context (suite, gsad_validator, validate_name);
   add_test_with_context (suite, gsad_validator, validate_comment);
   add_test_with_context (suite, gsad_validator, validate_agent_installer_id);
@@ -276,7 +279,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_validator, alias_hosts_hosts_manual);
   add_test_with_context (suite, gsad_validator, alias_hostpath_scanner_host);
 
-  int ret = run_test_suite (suite, create_text_reporter ());
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
   destroy_test_suite (suite);
+
   return ret;
 }


### PR DESCRIPTION
## What

Close leaks in the tests.

## Why

Makes it easier to see actual leaks, when compiling with `-fsanitiize=address`.

There are still some leaks shown in gsad-args-test, but those need changes to the actual arg parsing.