### PR TITLE
gsad http module cleanup

### DIFF
--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -481,14 +481,14 @@ gsad_http_send_reauthentication (gsad_http_connection_t *connection,
 }
 
 /**
- * @brief Attach expired SID cookie to response.
+ * @brief Internal function to attach expired SID cookie to response.
  *
  * @param[in]  response  Response.
  *
  * @return MHD_NO in case of problems. MHD_YES if all is OK.
  */
-gsad_http_result_t
-remove_sid (gsad_http_response_t *response)
+static gsad_http_result_t
+gsad_http_remove_sid (gsad_http_response_t *response)
 {
   int ret;
   gchar *value;
@@ -626,7 +626,7 @@ attach_remove_sid (gsad_http_response_t *response, const gchar *sid)
     {
       if (str_equal (sid, REMOVE_SID))
         {
-          if (remove_sid (response) == MHD_NO)
+          if (gsad_http_remove_sid (response) == MHD_NO)
             {
               MHD_destroy_response (response);
               g_warning ("%s: failed to remove SID, dropping request",

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -529,15 +529,16 @@ remove_sid (gsad_http_response_t *response)
 }
 
 /**
- * @brief Attach SID cookie to a response, resetting "expire" arg.
+ * @brief Internal function to attach SID cookie to a response, resetting
+ * "expire" arg.
  *
  * @param[in]  response  Response.
  * @param[in]  sid       Session ID.
  *
  * @return MHD_NO in case of problems. MHD_YES if all is OK.
  */
-gsad_http_result_t
-attach_sid (gsad_http_response_t *response, const char *sid)
+static gsad_http_result_t
+gsad_http_attach_sid (gsad_http_response_t *response, const char *sid)
 {
   int ret, timeout;
   gchar *value;
@@ -635,7 +636,7 @@ attach_remove_sid (gsad_http_response_t *response, const gchar *sid)
         }
       else
         {
-          if (attach_sid (response, sid) == MHD_NO)
+          if (gsad_http_attach_sid (response, sid) == MHD_NO)
             {
               MHD_destroy_response (response);
               g_warning ("%s: failed to attach SID, dropping request",

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -894,7 +894,8 @@ gsad_http_add_forbid_caching_headers (gsad_http_response_t *response)
  * @return  0 success, 1 invalid UTF-8 in X-Real-IP header
  */
 int
-get_client_address (gsad_http_connection_t *conn, char *client_address)
+gsad_http_get_client_address (gsad_http_connection_t *conn,
+                              gchar *client_address)
 {
   const char *x_real_ip;
   gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -35,6 +35,174 @@
 #define G_LOG_DOMAIN "gsad http"
 
 /**
+ * @brief Internal function to attach expired SID cookie to response.
+ *
+ * @param[in]  response  Response.
+ *
+ * @return MHD_NO in case of problems. MHD_YES if all is OK.
+ */
+static gsad_http_result_t
+gsad_http_remove_sid (gsad_http_response_t *response)
+{
+  int ret;
+  gchar *value;
+  gchar *locale;
+  char expires[EXPIRES_LENGTH + 1];
+  struct tm expire_time_broken;
+  time_t expire_time;
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+
+  /* Set up the expires param. */
+  locale = g_strdup (setlocale (LC_ALL, NULL));
+  setlocale (LC_ALL, "C");
+
+  expire_time = time (NULL);
+  if (localtime_r (&expire_time, &expire_time_broken) == NULL)
+    abort ();
+  ret = strftime (expires, EXPIRES_LENGTH, "%a, %d %b %Y %T GMT",
+                  &expire_time_broken);
+  if (ret == 0)
+    abort ();
+
+  setlocale (LC_ALL, locale);
+  g_free (locale);
+
+  /* Add the cookie.
+   *
+   * Tim Brown's suggested cookie included a domain attribute.  How would
+   * we get the domain in here?  Maybe a --domain option. */
+
+  value = g_strdup_printf (
+    SID_COOKIE_NAME "=0; expires=%s; path=/; %sHTTPonly; SameSite=strict",
+    expires,
+    (gsad_settings_enable_secure_cookie (gsad_global_settings) ? "secure; "
+                                                               : ""));
+  ret = MHD_add_response_header (response, "Set-Cookie", value);
+  g_free (value);
+  return ret;
+}
+
+/**
+ * @brief Internal function to attach SID cookie to a response, resetting
+ * "expire" arg.
+ *
+ * @param[in]  response  Response.
+ * @param[in]  sid       Session ID.
+ *
+ * @return MHD_NO in case of problems. MHD_YES if all is OK.
+ */
+static gsad_http_result_t
+gsad_http_attach_sid (gsad_http_response_t *response, const char *sid)
+{
+  int ret, timeout;
+  gchar *value;
+  gchar *locale;
+  char expires[EXPIRES_LENGTH + 1];
+  struct tm expire_time_broken;
+  time_t now, expire_time;
+  gchar *tz;
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+
+  /* Set up the expires param. */
+
+  /* Store current TZ, switch to GMT. */
+  tz = getenv ("TZ") ? g_strdup (getenv ("TZ")) : NULL;
+  if (setenv ("TZ", "GMT", 1) == -1)
+    {
+      g_critical ("%s: failed to set TZ\n", __func__);
+      g_free (tz);
+      exit (EXIT_FAILURE);
+    }
+  tzset ();
+
+  locale = g_strdup (setlocale (LC_ALL, NULL));
+  setlocale (LC_ALL, "C");
+
+  timeout = gsad_settings_get_session_timeout (gsad_global_settings) * 60 + 30;
+
+  now = time (NULL);
+  expire_time = now + timeout;
+  if (localtime_r (&expire_time, &expire_time_broken) == NULL)
+    abort ();
+  ret = strftime (expires, EXPIRES_LENGTH, "%a, %d %b %Y %T GMT",
+                  &expire_time_broken);
+  if (ret == 0)
+    abort ();
+
+  setlocale (LC_ALL, locale);
+  g_free (locale);
+
+  /* Revert to stored TZ. */
+  if (tz)
+    {
+      if (setenv ("TZ", tz, 1) == -1)
+        {
+          g_warning ("%s: Failed to switch to original TZ", __func__);
+          g_free (tz);
+          exit (EXIT_FAILURE);
+        }
+    }
+  else
+    unsetenv ("TZ");
+  g_free (tz);
+
+  /* Add the cookie.
+   *
+   * Tim Brown's suggested cookie included a domain attribute.  How would
+   * we get the domain in here?  Maybe a --domain option. */
+
+  value = g_strdup_printf (
+    SID_COOKIE_NAME
+    "=%s; expires=%s; max-age=%d; path=/; %sHTTPonly; SameSite=strict",
+    sid, expires, timeout,
+    (gsad_settings_enable_secure_cookie (gsad_global_settings) ? "secure; "
+                                                               : ""));
+  ret = MHD_add_response_header (response, "Set-Cookie", value);
+  g_free (value);
+  return ret;
+}
+
+/**
+ * Internal function to attach or remove session id
+ *
+ * If sid is "0" the session id will be removed. Otherwise if the sid is not
+ * NULL the sid will be attached to the response.
+ *
+ * @param[in]  response  HTTP response
+ * @param[in]  sid       Session ID
+ *
+ * @return MHD_YES on success, MHD_NO on failure
+ */
+static gsad_http_result_t
+gsad_http_attach_remove_sid (gsad_http_response_t *response, const gchar *sid)
+{
+  if (sid)
+    {
+      if (str_equal (sid, REMOVE_SID))
+        {
+          if (gsad_http_remove_sid (response) == MHD_NO)
+            {
+              MHD_destroy_response (response);
+              g_warning ("%s: failed to remove SID, dropping request",
+                         __func__);
+              return MHD_NO;
+            }
+        }
+      else
+        {
+          if (gsad_http_attach_sid (response, sid) == MHD_NO)
+            {
+              MHD_destroy_response (response);
+              g_warning ("%s: failed to attach SID, dropping request",
+                         __func__);
+              return MHD_NO;
+            }
+        }
+    }
+  return MHD_YES;
+}
+
+/**
  * @brief Guess a content type from a file extension
  *
  * @param[in]  path  filename with extension
@@ -201,7 +369,7 @@ gsad_http_send_redirect_to_uri (gsad_http_connection_t *connection,
       return MHD_NO;
     }
 
-  if (attach_remove_sid (response, sid) == MHD_NO)
+  if (gsad_http_attach_remove_sid (response, sid) == MHD_NO)
     {
       MHD_destroy_response (response);
       g_warning ("%s: failed to attach SID, dropping request", __func__);
@@ -261,7 +429,7 @@ gsad_http_send_response_for_content (gsad_http_connection_t *connection,
     MHD_add_response_header (response, "Content-Disposition",
                              content_disposition);
 
-  if (attach_remove_sid (response, sid) == MHD_NO)
+  if (gsad_http_attach_remove_sid (response, sid) == MHD_NO)
     {
       return MHD_NO;
     }
@@ -296,7 +464,7 @@ gsad_http_send_response (gsad_http_connection_t *connection,
   content_type_t content_type;
   int status_code;
 
-  if (attach_remove_sid (response, sid) == MHD_NO)
+  if (gsad_http_attach_remove_sid (response, sid) == MHD_NO)
     {
       cmd_response_data_free (response_data);
       MHD_destroy_response (response);
@@ -480,173 +648,6 @@ gsad_http_send_reauthentication (gsad_http_connection_t *connection,
   return gsad_http_create_response (connection, xml, response_data, REMOVE_SID);
 }
 
-/**
- * @brief Internal function to attach expired SID cookie to response.
- *
- * @param[in]  response  Response.
- *
- * @return MHD_NO in case of problems. MHD_YES if all is OK.
- */
-static gsad_http_result_t
-gsad_http_remove_sid (gsad_http_response_t *response)
-{
-  int ret;
-  gchar *value;
-  gchar *locale;
-  char expires[EXPIRES_LENGTH + 1];
-  struct tm expire_time_broken;
-  time_t expire_time;
-  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
-
-  /* Set up the expires param. */
-  locale = g_strdup (setlocale (LC_ALL, NULL));
-  setlocale (LC_ALL, "C");
-
-  expire_time = time (NULL);
-  if (localtime_r (&expire_time, &expire_time_broken) == NULL)
-    abort ();
-  ret = strftime (expires, EXPIRES_LENGTH, "%a, %d %b %Y %T GMT",
-                  &expire_time_broken);
-  if (ret == 0)
-    abort ();
-
-  setlocale (LC_ALL, locale);
-  g_free (locale);
-
-  /* Add the cookie.
-   *
-   * Tim Brown's suggested cookie included a domain attribute.  How would
-   * we get the domain in here?  Maybe a --domain option. */
-
-  value = g_strdup_printf (
-    SID_COOKIE_NAME "=0; expires=%s; path=/; %sHTTPonly; SameSite=strict",
-    expires,
-    (gsad_settings_enable_secure_cookie (gsad_global_settings) ? "secure; "
-                                                               : ""));
-  ret = MHD_add_response_header (response, "Set-Cookie", value);
-  g_free (value);
-  return ret;
-}
-
-/**
- * @brief Internal function to attach SID cookie to a response, resetting
- * "expire" arg.
- *
- * @param[in]  response  Response.
- * @param[in]  sid       Session ID.
- *
- * @return MHD_NO in case of problems. MHD_YES if all is OK.
- */
-static gsad_http_result_t
-gsad_http_attach_sid (gsad_http_response_t *response, const char *sid)
-{
-  int ret, timeout;
-  gchar *value;
-  gchar *locale;
-  char expires[EXPIRES_LENGTH + 1];
-  struct tm expire_time_broken;
-  time_t now, expire_time;
-  gchar *tz;
-  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
-
-  /* Set up the expires param. */
-
-  /* Store current TZ, switch to GMT. */
-  tz = getenv ("TZ") ? g_strdup (getenv ("TZ")) : NULL;
-  if (setenv ("TZ", "GMT", 1) == -1)
-    {
-      g_critical ("%s: failed to set TZ\n", __func__);
-      g_free (tz);
-      exit (EXIT_FAILURE);
-    }
-  tzset ();
-
-  locale = g_strdup (setlocale (LC_ALL, NULL));
-  setlocale (LC_ALL, "C");
-
-  timeout = gsad_settings_get_session_timeout (gsad_global_settings) * 60 + 30;
-
-  now = time (NULL);
-  expire_time = now + timeout;
-  if (localtime_r (&expire_time, &expire_time_broken) == NULL)
-    abort ();
-  ret = strftime (expires, EXPIRES_LENGTH, "%a, %d %b %Y %T GMT",
-                  &expire_time_broken);
-  if (ret == 0)
-    abort ();
-
-  setlocale (LC_ALL, locale);
-  g_free (locale);
-
-  /* Revert to stored TZ. */
-  if (tz)
-    {
-      if (setenv ("TZ", tz, 1) == -1)
-        {
-          g_warning ("%s: Failed to switch to original TZ", __func__);
-          g_free (tz);
-          exit (EXIT_FAILURE);
-        }
-    }
-  else
-    unsetenv ("TZ");
-  g_free (tz);
-
-  /* Add the cookie.
-   *
-   * Tim Brown's suggested cookie included a domain attribute.  How would
-   * we get the domain in here?  Maybe a --domain option. */
-
-  value = g_strdup_printf (
-    SID_COOKIE_NAME
-    "=%s; expires=%s; max-age=%d; path=/; %sHTTPonly; SameSite=strict",
-    sid, expires, timeout,
-    (gsad_settings_enable_secure_cookie (gsad_global_settings) ? "secure; "
-                                                               : ""));
-  ret = MHD_add_response_header (response, "Set-Cookie", value);
-  g_free (value);
-  return ret;
-}
-
-/**
- * Attach or remove session id
- *
- * If sid is "0" the session id will be removed. Otherwise if the sid is not
- * NULL the sid will be attached to the response.
- *
- * @param[in]  response  HTTP response
- * @param[in]  sid       Session ID
- *
- * @return MHD_YES on success, MHD_NO on failure
- */
-gsad_http_result_t
-attach_remove_sid (gsad_http_response_t *response, const gchar *sid)
-{
-  if (sid)
-    {
-      if (str_equal (sid, REMOVE_SID))
-        {
-          if (gsad_http_remove_sid (response) == MHD_NO)
-            {
-              MHD_destroy_response (response);
-              g_warning ("%s: failed to remove SID, dropping request",
-                         __func__);
-              return MHD_NO;
-            }
-        }
-      else
-        {
-          if (gsad_http_attach_sid (response, sid) == MHD_NO)
-            {
-              MHD_destroy_response (response);
-              g_warning ("%s: failed to attach SID, dropping request",
-                         __func__);
-              return MHD_NO;
-            }
-        }
-    }
-  return MHD_YES;
-}
 /**
  * @brief Reads from a file.
  *

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -184,9 +184,6 @@ serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,
             size_t size);
 
 gsad_http_result_t
-remove_sid (gsad_http_response_t *response);
-
-gsad_http_result_t
 attach_remove_sid (gsad_http_response_t *response, const gchar *sid);
 
 /* exec_gmp functions are still in gsad.c */

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -187,9 +187,6 @@ gsad_http_result_t
 remove_sid (gsad_http_response_t *response);
 
 gsad_http_result_t
-attach_sid (gsad_http_response_t *response, const char *sid);
-
-gsad_http_result_t
 attach_remove_sid (gsad_http_response_t *response, const gchar *sid);
 
 /* exec_gmp functions are still in gsad.c */

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -175,7 +175,7 @@ gsad_http_create_not_found_response (cmd_response_data_t *);
 
 /* helper functions required in gsad_http */
 int
-get_client_address (gsad_http_connection_t *conn, char *client_address);
+gsad_http_get_client_address (gsad_http_connection_t *, gchar *);
 
 gsad_http_result_t
 serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -183,9 +183,6 @@ serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,
             const char *transfer_encoding, const char *data, uint64_t off,
             size_t size);
 
-gsad_http_result_t
-attach_remove_sid (gsad_http_response_t *response, const gchar *sid);
-
 /* exec_gmp functions are still in gsad.c */
 gsad_http_result_t
 exec_gmp_get (gsad_http_connection_t *connection,

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -147,7 +147,6 @@ get_user_from_connection (gsad_http_connection_t *connection,
   const gchar *cookie;
   const gchar *token;
   gchar client_address[INET6_ADDRSTRLEN];
-  int ret;
 
   token =
     MHD_lookup_connection_value (connection, MHD_GET_ARGUMENT_KIND, "token");
@@ -169,8 +168,7 @@ get_user_from_connection (gsad_http_connection_t *connection,
       return USER_BAD_MISSING_COOKIE;
     }
 
-  ret = get_client_address (connection, client_address);
-  if (ret == 1)
+  if (gsad_http_get_client_address (connection, client_address))
     {
       return USER_IP_ADDRESS_MISSMATCH;
     }
@@ -436,7 +434,7 @@ gsad_http_handle_gmp_post (gsad_http_handler_t *handler_next,
   gsad_connection_info_set_language (
     con_info, accept_language_to_env_fmt (accept_language));
 
-  if (get_client_address (connection, client_address))
+  if (gsad_http_get_client_address (connection, client_address))
     {
       gsad_http_send_response_for_content (
         connection, UTF8_ERROR_PAGE ("'X-Real-IP' header"),


### PR DESCRIPTION
## What

gsad http module cleanup

* Rename functions to use `gsad_http_` prefix
* Make functions only used in the module *private*

## Why

Use consistent function names. Cleaner module API.


