### PR TITLE
gsad http cleanup 2

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -194,10 +194,11 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
 
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred inside GSA daemon. "
-                          "Diagnostics: Invalid command.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred inside GSA daemon. "
+        "Diagnostics: Invalid command.",
+        response_data);
       return gsad_http_create_response (con, res, response_data, new_sid);
     }
 
@@ -215,15 +216,17 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
 
       if (params_given (params, "token") == 0)
-        res = gsad_message (NULL, "Internal error", __func__, __LINE__,
-                            "An internal error occurred inside GSA daemon. "
-                            "Diagnostics: Token missing.",
-                            response_data);
+        res = gsad_http_create_gsad_message (
+          NULL,
+          "An internal error occurred inside GSA daemon. "
+          "Diagnostics: Token missing.",
+          response_data);
       else
-        res = gsad_message (NULL, "Internal error", __func__, __LINE__,
-                            "An internal error occurred inside GSA daemon. "
-                            "Diagnostics: Token bad.",
-                            response_data);
+        res = gsad_http_create_gsad_message (
+          NULL,
+          "An internal error occurred inside GSA daemon. "
+          "Diagnostics: Token bad.",
+          response_data);
 
       return gsad_http_create_response (con, res, response_data, NULL);
     }
@@ -234,10 +237,11 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   if (ret == USER_BAD_TOKEN)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      res = gsad_message (NULL, "Internal error", __func__, __LINE__,
-                          "An internal error occurred inside GSA daemon. "
-                          "Diagnostics: Bad token.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        NULL,
+        "An internal error occurred inside GSA daemon. "
+        "Diagnostics: Bad token.",
+        response_data);
       return gsad_http_create_response (con, res, response_data, NULL);
     }
 
@@ -306,11 +310,12 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     case 1: /* manager closed connection */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Manager closed the connection.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Manager closed the connection.",
+        response_data);
       break;
     case 2: /* auth failed */
       cmd_response_data_free (response_data);
@@ -319,29 +324,32 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     case 3: /* timeout */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Connection timeout.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Connection timeout.",
+        response_data);
       break;
     case 4: /* can't connect to manager */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_SERVICE_UNAVAILABLE);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Could not open a connection.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Could not open a connection.",
+        response_data);
       break;
     default: /* unknown error */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Unknown error.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Unknown error.",
+        response_data);
     }
 
   if (res)
@@ -479,10 +487,11 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   else
   {
     cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-    res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                        "An internal error occurred inside GSA daemon. "
-                        "Diagnostics: Unknown command.",
-                        response_data);
+    res = gsad_http_create_gsad_message (
+      credentials,
+      "An internal error occurred inside GSA daemon. "
+      "Diagnostics: Unknown command.",
+      response_data);
   }
 
   ret = gsad_http_create_response (con, res, response_data, new_sid);
@@ -785,10 +794,11 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   else
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred inside GSA daemon. "
-                          "Diagnostics: No valid command for gmp.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred inside GSA daemon. "
+        "Diagnostics: No valid command for gmp.",
+        response_data);
       return gsad_http_create_response (con, res, response_data, NULL);
     }
 
@@ -815,11 +825,12 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     case 1: /* manager closed connection */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Manager closed the connection.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Manager closed the connection.",
+        response_data);
       break;
     case 2: /* auth failed */
       cmd_response_data_free (response_data);
@@ -828,29 +839,32 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     case 3: /* timeout */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Connection timeout.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Connection timeout.",
+        response_data);
       break;
     case 4: /* can't connect to manager */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_SERVICE_UNAVAILABLE);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Could not open a connection.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Could not open a connection.",
+        response_data);
       break;
     default: /* unknown error */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not connect to manager daemon. "
-                          "Unknown error.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Could not connect to manager daemon. "
+        "Unknown error.",
+        response_data);
     }
 
   if (res)
@@ -1068,10 +1082,11 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   else
   {
     cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-    res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                        "An internal error occurred inside GSA daemon. "
-                        "Diagnostics: Unknown command.",
-                        response_data);
+    res = gsad_http_create_gsad_message (
+      credentials,
+      "An internal error occurred inside GSA daemon. "
+      "Diagnostics: Unknown command.",
+      response_data);
   }
 
   res_len = cmd_response_data_get_content_length (response_data);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -18,7 +18,7 @@
 #include "gsad_gmp_arguments.h" /* for gmp_arguments_t */
 #include "gsad_gmp_auth.h"      /* for authenticate_gmp */
 #include "gsad_gmp_request.h"   /* for gmp_request() */
-#include "gsad_http.h"          /* for gsad_message */
+#include "gsad_http.h"          /* for gsad_http_create_gsad_message */
 #include "gsad_i18n.h"
 #include "gsad_manager.h" /* for gsad_manager_connect_with_username_password */
 #include "gsad_params.h"
@@ -400,8 +400,8 @@ check_modify_config (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to read command to manager daemon.",
@@ -416,8 +416,8 @@ check_modify_config (gvm_connection_t *connection,
       free_entity (entity);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to parse status_text from response.",
@@ -779,8 +779,8 @@ get_entity (gvm_connection_t *connection, const char *type,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a resource list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -796,8 +796,8 @@ get_entity (gvm_connection_t *connection, const char *type,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting resources list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -810,9 +810,8 @@ get_entity (gvm_connection_t *connection, const char *type,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       g_free (cmd);
@@ -912,8 +911,8 @@ get_entities (gvm_connection_t *connection, const char *type,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a resource list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -932,8 +931,8 @@ get_entities (gvm_connection_t *connection, const char *type,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting resources list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -946,9 +945,8 @@ get_entities (gvm_connection_t *connection, const char *type,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_free (cmd);
       g_string_free (xml, TRUE);
@@ -1156,8 +1154,8 @@ export_resource (gvm_connection_t *connection, const char *type,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a resource. "
         "The resource could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1170,8 +1168,8 @@ export_resource (gvm_connection_t *connection, const char *type,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a resource. "
         "The resource could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1190,8 +1188,8 @@ export_resource (gvm_connection_t *connection, const char *type,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a resource. "
         "The resource could not be delivered. "
         "Diagnostics: Failure to receive resource from manager daemon.",
@@ -1210,22 +1208,22 @@ export_resource (gvm_connection_t *connection, const char *type,
       switch (ret)
         {
         case 1:
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Internal error.",
@@ -1299,8 +1297,8 @@ export_many (gvm_connection_t *connection, const char *type,
           g_free (filter_escaped);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a list. "
             "The list could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -1322,8 +1320,8 @@ export_many (gvm_connection_t *connection, const char *type,
           g_free (filter_escaped);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a list. "
             "The list could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -1343,8 +1341,8 @@ export_many (gvm_connection_t *connection, const char *type,
           g_free (filter_escaped);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a list. "
             "The list could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -1358,8 +1356,8 @@ export_many (gvm_connection_t *connection, const char *type,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a list. "
         "The list could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1380,22 +1378,22 @@ export_many (gvm_connection_t *connection, const char *type,
       switch (ret)
         {
         case 1:
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Internal error.",
@@ -1460,8 +1458,8 @@ delete_resource (gvm_connection_t *connection, const char *type,
     {
       g_free (id_name);
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting a resource. "
         "The resource was not deleted. "
         "Diagnostics: Required parameter resource_id was NULL.",
@@ -1499,8 +1497,8 @@ delete_resource (gvm_connection_t *connection, const char *type,
       g_free (extra_attribs);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting a resource. "
         "The resource is not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1515,8 +1513,8 @@ delete_resource (gvm_connection_t *connection, const char *type,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting a resource. "
         "It is unclear whether the resource has been deleted or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -1623,8 +1621,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
         param_name);
       g_free (param_name);
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      html = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           message, response_data);
+      html =
+        gsad_http_create_gsad_message (credentials, message, response_data);
       g_free (message);
       return html;
     }
@@ -1640,8 +1638,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while performing an action. "
         "The resource remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1649,8 +1647,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while performing an action. "
         "It is unclear whether the resource has been affected. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1658,8 +1656,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while performing an action. "
         "It is unclear whether the resource has been affected. "
         "Diagnostics: Internal Error.",
@@ -1788,8 +1786,8 @@ create_report_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new report. "
         "No new report was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1797,8 +1795,8 @@ create_report_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new report. "
         "It is unclear whether the report has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1806,8 +1804,8 @@ create_report_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new report. "
         "It is unclear whether the report has been created or not. "
         "Diagnostics: Internal Error.",
@@ -1865,8 +1863,8 @@ create_import_task_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating an import task. "
         "No task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1874,8 +1872,8 @@ create_import_task_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating an import task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1883,8 +1881,8 @@ create_import_task_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating an import task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2103,8 +2101,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new task. "
         "No new task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2112,8 +2110,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2121,8 +2119,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2157,8 +2155,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new tag. "
                 "No new tag was created. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -2167,8 +2165,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new tag. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -2177,8 +2175,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new task. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Internal Error.",
@@ -2354,8 +2352,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new agent-group task. "
         "No new task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2363,8 +2361,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new agent-group task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2372,8 +2370,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new agent-group task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2408,8 +2406,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new tag. "
                 "No new tag was created. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -2418,8 +2416,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new tag. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -2428,8 +2426,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new task. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Internal Error.",
@@ -2605,8 +2603,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new oci image task. "
         "No new task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2614,8 +2612,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new oci image task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2623,8 +2621,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new oci image task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2659,8 +2657,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new tag. "
                 "No new tag was created. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -2669,8 +2667,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new tag. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -2679,8 +2677,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while creating a new task. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Internal Error.",
@@ -2923,8 +2921,8 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a task. "
         "The task was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2932,8 +2930,8 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2941,8 +2939,8 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -3022,8 +3020,8 @@ save_import_task_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an import task. "
         "No new task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -3031,8 +3029,8 @@ save_import_task_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an import task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -3040,8 +3038,8 @@ save_import_task_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an import task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -3150,8 +3148,8 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent-group task. "
         "The task was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -3159,8 +3157,8 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent-group task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -3168,8 +3166,8 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent-group task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -3298,8 +3296,8 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an oci image task. "
         "The task was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -3307,8 +3305,8 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an oci image task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -3316,8 +3314,8 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an oci image task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -3455,8 +3453,8 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while moving a task. "
         "The task was not moved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -3464,8 +3462,8 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while moving a task. "
         "It is unclear whether the task has been moved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -3473,8 +3471,8 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while moving a task. "
         "It is unclear whether the task has been moved or not. "
         "Diagnostics: Internal Error.",
@@ -4033,8 +4031,8 @@ create_credential_gmp (gvm_connection_t *connection,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while creating a new credential. "
             "The credential could not be created. "
             "Diagnostics: Unrecognized credential type.",
@@ -4050,8 +4048,8 @@ create_credential_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new credential. "
         "It is unclear whether the credential has been created or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4059,8 +4057,8 @@ create_credential_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new credential. "
         "It is unclear whether the credential has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4068,8 +4066,8 @@ create_credential_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new credential. "
         "It is unclear whether the credential has been created or not. "
         "Diagnostics: Internal Error.",
@@ -4166,8 +4164,8 @@ download_credential_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a credential. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -4183,8 +4181,8 @@ download_credential_gmp (gvm_connection_t *connection,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a credential. "
             "The credential is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -4220,8 +4218,8 @@ download_credential_gmp (gvm_connection_t *connection,
           free_entity (entity);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a credential. "
             "The credential could not be delivered. "
             "Diagnostics: Failure to receive credential from manager daemon.",
@@ -4237,8 +4235,8 @@ download_credential_gmp (gvm_connection_t *connection,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a credential. "
             "The credential could not be delivered. "
             "Diagnostics: Failure to receive credential from manager daemon.",
@@ -4269,8 +4267,8 @@ download_credential_gmp (gvm_connection_t *connection,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           free_entity (entity);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a credential. "
             "The credential could not be delivered. "
             "Diagnostics: Failure to parse credential from manager daemon.",
@@ -4565,8 +4563,8 @@ modify_credential_store_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a credential store. "
         "The credential store was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4574,8 +4572,8 @@ modify_credential_store_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a credential store. "
         "It is unclear whether the credential store has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4583,8 +4581,8 @@ modify_credential_store_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a credential store. "
         "It is unclear whether the credential store has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -4631,8 +4629,8 @@ verify_credential_store_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while verifying a credential store. "
         "The credential store was not verified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4640,8 +4638,8 @@ verify_credential_store_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while verifying a credential store. "
         "It is unclear whether the credential store was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4649,8 +4647,8 @@ verify_credential_store_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while verifying a credential store. "
         "It is unclear whether the credential store was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -5000,8 +4998,8 @@ save_credential_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Credential. "
         "The Credential was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -5009,8 +5007,8 @@ save_credential_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Credential. "
         "It is unclear whether the Credential has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5018,8 +5016,8 @@ save_credential_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Credential. "
         "It is unclear whether the Credential has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -5204,24 +5202,24 @@ get_aggregate_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Internal Error.",
         response_data);
@@ -5278,8 +5276,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting Report "
         "Formats for new alert. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -5287,8 +5285,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting Report "
         "Formats for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5296,12 +5294,13 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting Report "
-                           "Formats for new alert. It is unclear whether"
-                           " the alert has been saved or not. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting Report "
+        "Formats for new alert. It is unclear whether"
+        " the alert has been saved or not. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
   g_string_append (xml, response);
   g_free (response);
@@ -5320,8 +5319,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         case 1:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting Report "
             "Configs for new alert. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -5329,8 +5328,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         case 2:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting Report "
             "Configs for new alert. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -5338,8 +5337,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         default:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting Report "
             "Configs for new alert. It is unclear whether"
             " the alert has been saved or not. "
@@ -5363,8 +5362,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting Report "
         "Filters for new alert. "
         "The task was not saved. "
@@ -5373,8 +5372,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting Report "
         "Filters for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5382,11 +5381,12 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting Report "
-                           "Filters for new alert. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting Report "
+        "Filters for new alert. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
   g_string_append (xml, response);
   g_free (response);
@@ -5406,8 +5406,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting Tasks"
         " for new alert. "
         "The task was not saved. "
@@ -5416,8 +5416,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting Tasks"
         " for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5425,11 +5425,12 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting Tasks"
-                           " for new alert. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting Tasks"
+        " for new alert. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
   g_string_append (xml, response);
   g_free (response);
@@ -5449,8 +5450,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting"
         " Credentials for new alert. "
         "The task was not saved. "
@@ -5459,8 +5460,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting"
         " Credentials for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5468,11 +5469,12 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting"
-                           " Credentials for new alert. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting"
+        " Credentials for new alert. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
 
   g_string_append (xml, response);
@@ -5865,8 +5867,8 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new alert. "
         "No new alert was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -5874,8 +5876,8 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5883,8 +5885,8 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Internal Error.",
@@ -6004,11 +6006,12 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (alert_id == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while editing an alert. "
-                           "The alert remains as it was. "
-                           "Diagnostics: Required parameter alert_id was NULL.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while editing an alert. "
+        "The alert remains as it was. "
+        "Diagnostics: Required parameter alert_id was NULL.",
+        response_data);
     }
 
   if (next == NULL)
@@ -6023,8 +6026,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting alert info. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -6049,8 +6052,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting alert info. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -6067,8 +6070,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting report formats. "
             "The current list of report formats is not available. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -6080,8 +6083,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting report formats. "
             "The current list of report formats is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -6100,8 +6103,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting report configs. "
             "The current list of report configs is not available. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -6113,8 +6116,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting report configs. "
             "The current list of report configs is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -6132,8 +6135,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting the list "
             "of filters. "
             "The current list of filters is not available. "
@@ -6146,8 +6149,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting the list "
             "of filters. "
             "The current list of filters is not available. "
@@ -6170,8 +6173,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting the list "
             "of tasks. "
             "The current list of tasks is not available. "
@@ -6184,8 +6187,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting the list "
             "of tasks. "
             "The current list of tasks is not available. "
@@ -6207,8 +6210,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting the list "
             "of credentials. "
             "The current list of tasks is not available. "
@@ -6221,8 +6224,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting the list "
             "of credentials. "
             "The current list of tasks is not available. "
@@ -6363,8 +6366,8 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a new alert. "
         "No new alert was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6372,8 +6375,8 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -6381,8 +6384,8 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Internal Error.",
@@ -6419,10 +6422,11 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          GSAD_STATUS_INVALID_REQUEST);
-      return gsad_message (credentials, "Invalid request", __func__, __LINE__,
-                           "Missing parameter alert_id."
-                           "Diagnostics: Required parameter was NULL.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "Missing parameter alert_id."
+        "Diagnostics: Required parameter was NULL.",
+        response_data);
     }
 
   /* Test the alert. */
@@ -6433,8 +6437,8 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while testing an alert. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -6445,8 +6449,8 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while testing an alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -6727,8 +6731,8 @@ create_target_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new target. "
         "No new target was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6736,8 +6740,8 @@ create_target_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new target. "
         "It is unclear whether the target has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -6745,8 +6749,8 @@ create_target_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new target. "
         "It is unclear whether the target has been created or not. "
         "Diagnostics: Internal Error.",
@@ -6800,8 +6804,8 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while cloning a resource. "
             "The resource was not cloned. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -6817,8 +6821,8 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while cloning a resource. "
         "The resource was not cloned. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6830,8 +6834,8 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while cloning a resource. "
         "It is unclear whether the resource has been cloned or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -6898,8 +6902,8 @@ restore_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while restoring a resource. "
         "The resource was not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6910,8 +6914,8 @@ restore_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while restoring a resource. "
         "It is unclear whether the resource has been restored or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -6950,8 +6954,8 @@ empty_trashcan_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while emptying the trashcan. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -6961,8 +6965,8 @@ empty_trashcan_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while emptying the trashcan. "
         "Diagnostics: Failure to read response from manager daemon.",
         response_data);
@@ -7053,8 +7057,8 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new tag. "
         "No new tag was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7063,8 +7067,8 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new tag. "
         "It is unclear whether the tag has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7073,8 +7077,8 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new tag. "
         "It is unclear whether the tag has been created or not. "
         "Diagnostics: Internal Error.",
@@ -7193,33 +7197,36 @@ save_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while saving a tag. "
-                           "The tag remains the same. "
-                           "Diagnostics: Failure to send command to "
-                           "manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while saving a tag. "
+        "The tag remains the same. "
+        "Diagnostics: Failure to send command to "
+        "manager daemon.",
+        response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while saving a tag. "
-                           "It is unclear whether the tag has been saved "
-                           "or not. "
-                           "Diagnostics: Failure to receive response from "
-                           "manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while saving a tag. "
+        "It is unclear whether the tag has been saved "
+        "or not. "
+        "Diagnostics: Failure to receive response from "
+        "manager daemon.",
+        response_data);
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while saving a tag. "
-                           "It is unclear whether the tag has been saved "
-                           "or not. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while saving a tag. "
+        "It is unclear whether the tag has been saved "
+        "or not. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
 
   g_string_free (command, TRUE);
@@ -7358,12 +7365,13 @@ toggle_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while modifying a tag. "
-                           "The tag is not modified. "
-                           "Diagnostics: Failure to send command to"
-                           " manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while modifying a tag. "
+        "The tag is not modified. "
+        "Diagnostics: Failure to send command to"
+        " manager daemon.",
+        response_data);
     }
 
   entity = NULL;
@@ -7371,13 +7379,14 @@ toggle_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while modifying a tag. "
-                           "It is unclear whether the tag has been modified"
-                           " or not. "
-                           "Diagnostics: Failure to read response from"
-                           " manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while modifying a tag. "
+        "It is unclear whether the tag has been modified"
+        " or not. "
+        "Diagnostics: Failure to read response from"
+        " manager daemon.",
+        response_data);
     }
 
   html = response_from_entity (connection, credentials, params, entity,
@@ -7682,8 +7691,8 @@ save_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying target. "
         "No target was modified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7695,8 +7704,8 @@ save_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying a target. "
         "It is unclear whether the target has been modified or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7799,8 +7808,8 @@ create_config_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new config. "
         "No new config was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7808,8 +7817,8 @@ create_config_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new config. "
         "It is unclear whether the config has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7817,8 +7826,8 @@ create_config_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new config. "
         "It is unclear whether the config has been created or not. "
         "Diagnostics: Internal Error.",
@@ -7870,8 +7879,8 @@ import_config_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a config. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7879,8 +7888,8 @@ import_config_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a config. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7888,8 +7897,8 @@ import_config_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a config. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -8014,8 +8023,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8061,8 +8070,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               g_free (value);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while saving a config. "
                 "It is unclear whether the entire config has been saved. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -8100,8 +8109,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving a config. "
             "It is unclear whether the entire config has been saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -8128,8 +8137,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               {
                 cmd_response_data_set_status_code (
                   response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                return gsad_message (
-                  credentials, "Internal error", __func__, __LINE__,
+                return gsad_http_create_gsad_message (
+                  credentials,
                   "An internal error occurred while saving a config. "
                   "It is unclear whether the entire config has been saved. "
                   "Diagnostics: Failure to send command to manager daemon.",
@@ -8163,8 +8172,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                 {
                   cmd_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                  return gsad_message (
-                    credentials, "Internal error", __func__, __LINE__,
+                  return gsad_http_create_gsad_message (
+                    credentials,
                     "An internal error occurred while saving a config. "
                     "It is unclear whether the entire config has been saved. "
                     "Diagnostics: Failure to send command to manager daemon.",
@@ -8179,8 +8188,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving a config. "
             "It is unclear whether the entire config has been saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -8240,8 +8249,8 @@ get_config_family (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8253,8 +8262,8 @@ get_config_family (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -8359,8 +8368,8 @@ edit_config_family_all_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8372,8 +8381,8 @@ edit_config_family_all_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -8428,8 +8437,8 @@ save_config_family_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8449,8 +8458,8 @@ save_config_family_gmp (gvm_connection_t *connection,
           {
             cmd_response_data_set_status_code (response_data,
                                                MHD_HTTP_INTERNAL_SERVER_ERROR);
-            return gsad_message (
-              credentials, "Internal error", __func__, __LINE__,
+            return gsad_http_create_gsad_message (
+              credentials,
               "An internal error occurred while saving a config. "
               "It is unclear whether the entire config has been saved. "
               "Diagnostics: Failure to send command to manager daemon.",
@@ -8464,8 +8473,8 @@ save_config_family_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8520,8 +8529,8 @@ get_config_nvt_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8533,8 +8542,8 @@ get_config_nvt_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -8701,8 +8710,8 @@ save_config_nvt_gmp (gvm_connection_t *connection,
                   g_free (value);
                   cmd_response_data_set_status_code (response_data,
                                                      MHD_HTTP_BAD_REQUEST);
-                  return gsad_message (
-                    credentials, "Internal error", __func__, __LINE__,
+                  return gsad_http_create_gsad_message (
+                    credentials,
                     "An internal error occurred while saving a config. "
                     "It is unclear whether the entire config has been saved. "
                     "Diagnostics: Required parameter was NULL.",
@@ -8761,8 +8770,8 @@ save_config_nvt_gmp (gvm_connection_t *connection,
               g_free (value);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while saving a config. "
                 "It is unclear whether the entire config has been saved. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -9002,8 +9011,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a preference file. "
         "The file could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9016,8 +9025,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a preference file. "
         "The file could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9045,8 +9054,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a preference file. "
         "The file could not be delivered. "
         "Diagnostics: Failure to receive file from manager daemon.",
@@ -9227,8 +9236,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a report. "
         "The report could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9246,8 +9255,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
             {
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -9259,8 +9268,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Response from manager daemon did not contain a "
@@ -9282,8 +9291,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                     case 1:
                       cmd_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                      return gsad_message (
-                        credentials, "Internal error", __func__, __LINE__,
+                      return gsad_http_create_gsad_message (
+                        credentials,
                         "An internal error occurred while getting a setting. "
                         "The setting could not be delivered. "
                         "Diagnostics: Failure to send command to manager "
@@ -9292,8 +9301,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                     case 2:
                       cmd_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                      return gsad_message (
-                        credentials, "Internal error", __func__, __LINE__,
+                      return gsad_http_create_gsad_message (
+                        credentials,
                         "An internal error occurred while getting a setting. "
                         "The setting could not be delivered. "
                         "Diagnostics: Failure to receive response from manager "
@@ -9302,8 +9311,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                     default:
                       cmd_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                      return gsad_message (
-                        credentials, "Internal error", __func__, __LINE__,
+                      return gsad_http_create_gsad_message (
+                        credentials,
                         "An internal error occurred while getting a setting. "
                         "The setting could not be delivered. "
                         "Diagnostics: Internal error.",
@@ -9346,8 +9355,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
             {
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -9392,8 +9401,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                         case 1:
                           cmd_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                          return gsad_message (
-                            credentials, "Internal error", __func__, __LINE__,
+                          return gsad_http_create_gsad_message (
+                            credentials,
                             "An internal error occurred while getting a "
                             "setting. "
                             "The setting could not be delivered. "
@@ -9403,8 +9412,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                         case 2:
                           cmd_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                          return gsad_message (
-                            credentials, "Internal error", __func__, __LINE__,
+                          return gsad_http_create_gsad_message (
+                            credentials,
                             "An internal error occurred while getting a "
                             "setting. "
                             "The setting could not be delivered. "
@@ -9414,8 +9423,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                         default:
                           cmd_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-                          return gsad_message (
-                            credentials, "Internal error", __func__, __LINE__,
+                          return gsad_http_create_gsad_message (
+                            credentials,
                             "An internal error occurred while getting a "
                             "setting. "
                             "The setting could not be delivered. "
@@ -9456,8 +9465,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
               free_entity (entity);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive report from manager daemon.",
@@ -9483,8 +9492,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
             {
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -9497,9 +9506,9 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
               set_http_status_from_entity (entity, response_data);
 
-              message = gsad_message (
-                credentials, "Error", __FUNCTION__, __LINE__,
-                entity_attribute (entity, "status_text"), response_data);
+              message = gsad_http_create_gsad_message (
+                credentials, entity_attribute (entity, "status_text"),
+                response_data);
 
               g_string_free (xml, TRUE);
               free_entity (entity);
@@ -9542,8 +9551,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while getting a report. "
             "The report could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -9623,8 +9632,8 @@ get_report_errors_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report errors. "
         "The report errors could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9638,8 +9647,8 @@ get_report_errors_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report errors. "
         "The report errors could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9652,9 +9661,8 @@ get_report_errors_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);
@@ -9720,8 +9728,8 @@ get_report_hosts_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report hosts. "
         "The report hosts could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9735,8 +9743,8 @@ get_report_hosts_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report hosts. "
         "The report hosts could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9749,9 +9757,8 @@ get_report_hosts_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);
@@ -9815,8 +9822,8 @@ get_report_ports_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report ports. "
         "The report ports could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9830,8 +9837,8 @@ get_report_ports_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report ports. "
         "The report ports could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9844,9 +9851,8 @@ get_report_ports_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);
@@ -9911,8 +9917,8 @@ get_report_tls_certificates_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report TLS certificates. "
         "The report TLS certificates could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9926,8 +9932,8 @@ get_report_tls_certificates_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting report TLS certificates. "
         "The report TLS certificates could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9940,9 +9946,8 @@ get_report_tls_certificates_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);
@@ -9983,10 +9988,11 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if ((alert_id == NULL) || (report_id == NULL))
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Bad Request", __func__, __LINE__,
-                           "Missing parameter alert_id or report_id. "
-                           "Diagnostics: Required parameter was NULL.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "Missing parameter alert_id or report_id. "
+        "Diagnostics: Required parameter was NULL.",
+        response_data);
     }
 
   filter = params_value (params, "filter");
@@ -10009,8 +10015,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a report. "
         "The report could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10021,12 +10027,13 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting a report. "
-                           "The report could not be delivered. "
-                           "Diagnostics: Failure to receive response from "
-                           "manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting a report. "
+        "The report could not be delivered. "
+        "Diagnostics: Failure to receive response from "
+        "manager daemon.",
+        response_data);
     }
 
   status = entity_attribute (entity, "status");
@@ -10035,8 +10042,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       free_entity (entity);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting a report. "
         "The report could not be delivered. "
         "Diagnostics: Failure to parse response from manager daemon.",
@@ -10046,10 +10053,11 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       free_entity (entity);
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Failed", __func__, __LINE__,
-                           "Running the report alert failed."
-                           "The report could not be delivered.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "Running the report alert failed."
+        "The report could not be delivered.",
+        response_data);
     }
 
   html = response_from_entity (connection, credentials, params, entity,
@@ -10142,10 +10150,10 @@ download_ssl_cert (gvm_connection_t *connection,
   if (ssl_cert == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred."
-                           " Diagnostics: ssl_cert was NULL.",
-                           response_data);
+      return gsad_http_create_gsad_message (credentials,
+                                            "An internal error occurred."
+                                            " Diagnostics: ssl_cert was NULL.",
+                                            response_data);
     }
   /* The Base64 comes URI escaped as it may contain special characters. */
   unescaped = g_uri_unescape_string (ssl_cert, NULL);
@@ -10181,10 +10189,10 @@ download_ca_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (ca_pub == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred."
-                           " Diagnostics: ca_pub was NULL.",
-                           response_data);
+      return gsad_http_create_gsad_message (credentials,
+                                            "An internal error occurred."
+                                            " Diagnostics: ca_pub was NULL.",
+                                            response_data);
     }
   /* The Base64 comes URI escaped as it may contain special characters. */
   unescaped = g_uri_unescape_string (ca_pub, NULL);
@@ -10213,10 +10221,10 @@ download_key_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (key_pub == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred."
-                           " Diagnostics: key_pub was NULL.",
-                           response_data);
+      return gsad_http_create_gsad_message (credentials,
+                                            "An internal error occurred."
+                                            " Diagnostics: key_pub was NULL.",
+                                            response_data);
     }
 
   /* The Base64 comes URI escaped as it may contain special characters. */
@@ -10563,8 +10571,8 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new note. "
         "No new note was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10572,8 +10580,8 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new note. "
         "It is unclear whether the note has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10581,8 +10589,8 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new note. "
         "It is unclear whether the note has been created or not. "
         "Diagnostics: Internal Error.",
@@ -10681,8 +10689,8 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a note. "
         "The note remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10690,8 +10698,8 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a note. "
         "It is unclear whether the note has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10699,8 +10707,8 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a note. "
         "It is unclear whether the note has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -10865,8 +10873,8 @@ create_override_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new override. "
         "No new override was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10874,8 +10882,8 @@ create_override_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new override. "
         "It is unclear whether the override has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10883,8 +10891,8 @@ create_override_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new override. "
         "It is unclear whether the override has been created or not. "
         "Diagnostics: Internal Error.",
@@ -10994,8 +11002,8 @@ save_override_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a override. "
         "The override remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11003,8 +11011,8 @@ save_override_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a override. "
         "It is unclear whether the override has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11012,8 +11020,8 @@ save_override_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a override. "
         "It is unclear whether the override has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -11156,8 +11164,8 @@ verify_scanner_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while verifying a scanner. "
         "The scanner was not verified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11165,8 +11173,8 @@ verify_scanner_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while verifying a scanner. "
         "It is unclear whether the scanner was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11174,8 +11182,8 @@ verify_scanner_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while verifying a scanner. "
         "It is unclear whether the scanner was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11254,8 +11262,8 @@ create_scanner_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new scanner. "
         "No new scanner was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11263,8 +11271,8 @@ create_scanner_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new scanner. "
         "It is unclear whether the scanner has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11272,8 +11280,8 @@ create_scanner_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new scanner. "
         "It is unclear whether the scanner has been created or not. "
         "Diagnostics: Internal Error.",
@@ -11381,8 +11389,8 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a scanner. "
         "The scanner remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11390,8 +11398,8 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a scanner. "
         "It is unclear whether the scanner has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11399,8 +11407,8 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a scanner. "
         "It is unclear whether the scanner has been saved or not. "
         "Diagnostics: Unknown Error.",
@@ -11523,8 +11531,8 @@ create_schedule_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new schedule. "
         "No new schedule was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11532,8 +11540,8 @@ create_schedule_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new schedule. "
         "It is unclear whether the schedule has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11541,8 +11549,8 @@ create_schedule_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new schedule. "
         "It is unclear whether the schedule has been created or not. "
         "Diagnostics: Internal Error.",
@@ -11609,8 +11617,8 @@ get_system_reports_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the system reports. "
         "The current list of system reports is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11622,8 +11630,8 @@ get_system_reports_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the system reports. "
         "The current list of system reports is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11699,8 +11707,8 @@ get_system_report_gmp (gvm_connection_t *connection,
       g_free (gmp_command);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the system reports. "
         "The current list of system reports is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11713,8 +11721,8 @@ get_system_report_gmp (gvm_connection_t *connection,
       g_free (gmp_command);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the system reports. "
         "The current list of system reports is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12079,8 +12087,8 @@ create_report_config_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a Report Config. "
         "The Report Config was not created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12088,8 +12096,8 @@ create_report_config_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a Report Config. "
         "It is unclear whether the Report Config has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12097,8 +12105,8 @@ create_report_config_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a Report Config. "
         "It is unclear whether the Report Config has been created or not. "
         "Diagnostics: Internal Error.",
@@ -12189,8 +12197,8 @@ save_report_config_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Report Config. "
         "The Report Config was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12198,8 +12206,8 @@ save_report_config_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Report Config. "
         "It is unclear whether the Report Config has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12207,8 +12215,8 @@ save_report_config_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Report Config. "
         "It is unclear whether the Report Config has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -12342,8 +12350,8 @@ import_report_format_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a report format. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12351,8 +12359,8 @@ import_report_format_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a report format. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12360,8 +12368,8 @@ import_report_format_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a report format. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -12485,8 +12493,8 @@ save_report_format_gmp (gvm_connection_t *connection,
             case 1:
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while saving a Report Format. "
                 "The Report Format was not saved. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -12494,8 +12502,8 @@ save_report_format_gmp (gvm_connection_t *connection,
             case 2:
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while saving a Report Format. "
                 "It is unclear whether the Report Format has been saved or "
                 "not. "
@@ -12504,8 +12512,8 @@ save_report_format_gmp (gvm_connection_t *connection,
             default:
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while saving a Report Format. "
                 "It is unclear whether the Report Format has been saved or "
                 "not. "
@@ -12564,8 +12572,8 @@ save_report_format_gmp (gvm_connection_t *connection,
                   cmd_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
-                  return gsad_message (
-                    credentials, "Internal error", __func__, __LINE__,
+                  return gsad_http_create_gsad_message (
+                    credentials,
                     "An internal error occurred while saving a Report Format. "
                     "The Report Format was not saved. "
                     "Diagnostics: Failure to send command to manager daemon.",
@@ -12574,8 +12582,8 @@ save_report_format_gmp (gvm_connection_t *connection,
                   cmd_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
-                  return gsad_message (
-                    credentials, "Internal error", __func__, __LINE__,
+                  return gsad_http_create_gsad_message (
+                    credentials,
                     "An internal error occurred while saving a Report Format. "
                     "It is unclear whether the Report Format has been saved or "
                     "not. "
@@ -12586,8 +12594,8 @@ save_report_format_gmp (gvm_connection_t *connection,
                   cmd_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
-                  return gsad_message (
-                    credentials, "Internal error", __func__, __LINE__,
+                  return gsad_http_create_gsad_message (
+                    credentials,
                     "An internal error occurred while saving a Report Format. "
                     "It is unclear whether the Report Format has been saved or "
                     "not. "
@@ -12618,8 +12626,8 @@ save_report_format_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Report Format. "
         "The Report Format was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12627,8 +12635,8 @@ save_report_format_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Report Format. "
         "It is unclear whether the Report Format has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12636,8 +12644,8 @@ save_report_format_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Report Format. "
         "It is unclear whether the Report Format has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -12711,8 +12719,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (name == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while trying to start a wizard. "
         "Diagnostics: Required parameter 'name' was NULL.",
         response_data);
@@ -12749,8 +12757,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while running a wizard. "
         "The wizard did not start. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12758,8 +12766,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while running a wizard. "
         "It is unclear whether the wizard started or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12767,11 +12775,12 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while running a wizard. "
-                           "It is unclear whether the wizard started or not. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while running a wizard. "
+        "It is unclear whether the wizard started or not. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
 
   html = response_from_entity (connection, credentials, params, entity,
@@ -12791,8 +12800,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);                                          \
           cmd_response_data_set_status_code (response_data,                   \
                                              MHD_HTTP_INTERNAL_SERVER_ERROR); \
-          return gsad_message (                                               \
-            credentials, "Internal error", __func__, __LINE__,                \
+          return gsad_http_create_gsad_message (                              \
+            credentials,                                                      \
             "An internal error occurred while getting " name                  \
             " list for trash."                                                \
             "Diagnostics: Failure to send command to"                         \
@@ -12805,8 +12814,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
           g_string_free (xml, TRUE);                                          \
           cmd_response_data_set_status_code (response_data,                   \
                                              MHD_HTTP_INTERNAL_SERVER_ERROR); \
-          return gsad_message (                                               \
-            credentials, "Internal error", __func__, __LINE__,                \
+          return gsad_http_create_gsad_message (                              \
+            credentials,                                                      \
             "An internal error occurred while getting " name " list."         \
             "Diagnostics: Failure to receive response from"                   \
             " manager daemon.",                                               \
@@ -13525,8 +13534,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
         case 1:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "The settings remains the same. "
             "Diagnostics: Manager closed connection during authenticate.",
@@ -13534,8 +13543,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
         case 2:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Invalid Password", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "You tried to change your password, but the old"
             " password was not provided or was incorrect. "
             " Please enter the correct old password or remove"
@@ -13545,8 +13554,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
         default:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "The settings remains the same. "
             "Diagnostics: Internal Error.",
@@ -13566,8 +13575,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (passwd_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13582,8 +13591,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
@@ -13622,8 +13631,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (text_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13638,8 +13647,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
@@ -13689,8 +13698,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (max_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13706,8 +13715,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -13741,8 +13750,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (fname_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13758,8 +13767,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -13792,8 +13801,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (fname_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13809,8 +13818,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -13844,8 +13853,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (fname_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13861,8 +13870,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -13895,8 +13904,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (lang_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -13912,8 +13921,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -13940,8 +13949,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13956,8 +13965,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13986,8 +13995,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (text_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -14003,8 +14012,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -14039,8 +14048,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (text_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -14056,8 +14065,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -14094,8 +14103,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           gvm_connection_close (connection);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -14112,8 +14121,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           gvm_connection_close (connection);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -14147,8 +14156,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (time_format_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -14164,8 +14173,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -14199,8 +14208,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_free (date_format_64);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -14216,8 +14225,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           g_string_free (xml, TRUE);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -14379,8 +14388,8 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new group. "
         "No new group was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14388,8 +14397,8 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new group. "
         "It is unclear whether the group has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14397,8 +14406,8 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new group. "
         "It is unclear whether the group has been created or not. "
         "Diagnostics: Internal Error.",
@@ -14497,8 +14506,8 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a group. "
         "The group was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14506,8 +14515,8 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a group. "
         "It is unclear whether the group has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14515,8 +14524,8 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a group. "
         "It is unclear whether the group has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -14680,8 +14689,8 @@ create_permission_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a permission. "
         "The permission was not created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14689,8 +14698,8 @@ create_permission_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a permission. "
         "It is unclear whether the permission has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14698,8 +14707,8 @@ create_permission_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a permission. "
         "It is unclear whether the permission has been created or not. "
         "Diagnostics: Internal Error.",
@@ -14724,8 +14733,8 @@ create_permission_gmp (gvm_connection_t *connection,
     case 1:                                                                 \
       cmd_response_data_set_status_code (response_data,                     \
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);   \
-      return gsad_message (                                                 \
-        credentials, "Internal error", __func__, __LINE__,                  \
+      return gsad_http_create_gsad_message (                                \
+        credentials,                                                        \
         "An internal error occurred while creating a permission. "          \
         "The permission was not created. "                                  \
         "Diagnostics: Failure to send command to manager daemon.",          \
@@ -14733,8 +14742,8 @@ create_permission_gmp (gvm_connection_t *connection,
     case 2:                                                                 \
       cmd_response_data_set_status_code (response_data,                     \
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);   \
-      return gsad_message (                                                 \
-        credentials, "Internal error", __func__, __LINE__,                  \
+      return gsad_http_create_gsad_message (                                \
+        credentials,                                                        \
         "An internal error occurred while creating a permission. "          \
         "It is unclear whether the permission has been created or not. "    \
         "Diagnostics: Failure to receive response from manager daemon.",    \
@@ -14742,8 +14751,8 @@ create_permission_gmp (gvm_connection_t *connection,
     default:                                                                \
       cmd_response_data_set_status_code (response_data,                     \
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);   \
-      return gsad_message (                                                 \
-        credentials, "Internal error", __func__, __LINE__,                  \
+      return gsad_http_create_gsad_message (                                \
+        credentials,                                                        \
         "An internal error occurred while creating a permission. "          \
         "It is unclear whether the permission has been created or not. "    \
         "Diagnostics: Internal Error.",                                     \
@@ -15227,8 +15236,8 @@ save_permission_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying a permission. "
         "The permission was not modified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15236,8 +15245,8 @@ save_permission_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying a permission. "
         "It is unclear whether the permission has been modified or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15245,8 +15254,8 @@ save_permission_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying a permission. "
         "It is unclear whether the permission has been modified or not. "
         "Diagnostics: Internal Error.",
@@ -15307,8 +15316,8 @@ create_port_list_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new port list. "
         "No new port list was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15316,8 +15325,8 @@ create_port_list_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new port list. "
         "It is unclear whether the port list has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15325,8 +15334,8 @@ create_port_list_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new port list. "
         "It is unclear whether the port list has been created or not. "
         "Diagnostics: Internal Error.",
@@ -15390,8 +15399,8 @@ create_port_range_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a Port Range. "
         "The Port Range was not created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15399,8 +15408,8 @@ create_port_range_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a Port Range. "
         "It is unclear whether the Port Range has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15408,8 +15417,8 @@ create_port_range_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a Port Range. "
         "It is unclear whether the Port Range has been created or not. "
         "Diagnostics: Internal Error.",
@@ -15530,8 +15539,8 @@ save_port_list_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Port List. "
         "The Port List was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15539,8 +15548,8 @@ save_port_list_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Port List. "
         "It is unclear whether the Port List has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15548,8 +15557,8 @@ save_port_list_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a Port List. "
         "It is unclear whether the Port List has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -15635,8 +15644,8 @@ import_port_list_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a port_list. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15644,8 +15653,8 @@ import_port_list_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a port_list. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15653,8 +15662,8 @@ import_port_list_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while importing a port_list. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -15729,8 +15738,8 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new role. "
         "No new role was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15738,8 +15747,8 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new role. "
         "It is unclear whether the role has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15747,8 +15756,8 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new role. "
         "It is unclear whether the role has been created or not. "
         "Diagnostics: Internal Error.",
@@ -15901,8 +15910,8 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a role. "
         "The role was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15910,8 +15919,8 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a role. "
         "It is unclear whether the role has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15919,8 +15928,8 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a role. "
         "It is unclear whether the role has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -15960,8 +15969,8 @@ get_feeds_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the feed list. "
         "The current list of feeds is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15972,8 +15981,8 @@ get_feeds_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the feed. "
         "The current list of feeds is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16030,8 +16039,7 @@ sync_feed (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Feed synchronization is currently not available. "
         "Diagnostics: Failure to send command to manager daemon.",
         feed_name);
-      html = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           msg, response_data);
+      html = gsad_http_create_gsad_message (credentials, msg, response_data);
       g_free (msg);
       return html;
     }
@@ -16046,8 +16054,7 @@ sync_feed (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Feed synchronization is currently not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
         feed_name);
-      html = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           msg, response_data);
+      html = gsad_http_create_gsad_message (credentials, msg, response_data);
       g_free (msg);
       return html;
     }
@@ -16084,8 +16091,7 @@ sync_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "An internal error occurred while synchronizing with agents. "
         "Agent synchronization is currently not available. "
         "Diagnostics: Failure to send command to manager daemon.");
-      html = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           msg, response_data);
+      html = gsad_http_create_gsad_message (credentials, msg, response_data);
       g_free (msg);
       return html;
     }
@@ -16099,8 +16105,7 @@ sync_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "An internal error occurred while synchronizing with agents. "
         "Agent synchronization is currently not available. "
         "Diagnostics: Failure to receive response from manager daemon.");
-      html = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           msg, response_data);
+      html = gsad_http_create_gsad_message (credentials, msg, response_data);
       g_free (msg);
       return html;
     }
@@ -16270,8 +16275,8 @@ create_filter_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new alert. "
         "No new alert was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16279,8 +16284,8 @@ create_filter_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16288,8 +16293,8 @@ create_filter_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Internal Error.",
@@ -16407,8 +16412,8 @@ save_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       {
         cmd_response_data_set_status_code (response_data,
                                            MHD_HTTP_INTERNAL_SERVER_ERROR);
-        return gsad_message (
-          credentials, "Internal error", __func__, __LINE__,
+        return gsad_http_create_gsad_message (
+          credentials,
           "An internal error occurred while modifying a filter. "
           "The filter was not modified. "
           "Diagnostics: Failure to send command to manager daemon.",
@@ -16420,8 +16425,8 @@ save_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       {
         cmd_response_data_set_status_code (response_data,
                                            MHD_HTTP_INTERNAL_SERVER_ERROR);
-        return gsad_message (
-          credentials, "Internal error", __func__, __LINE__,
+        return gsad_http_create_gsad_message (
+          credentials,
           "An internal error occurred while modifying a filter. "
           "It is unclear whether the filter has been modified or not. "
           "Diagnostics: Failure to receive response from manager daemon.",
@@ -16525,8 +16530,8 @@ save_schedule_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a schedule. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16534,8 +16539,8 @@ save_schedule_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a schedule. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16543,8 +16548,8 @@ save_schedule_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a schedule. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -16614,24 +16619,24 @@ get_user (gvm_connection_t *connection, gsad_credentials_t *credentials,
         case 1:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Internal Error.",
             response_data);
@@ -16813,8 +16818,8 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new user. "
         "No new user was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16822,8 +16827,8 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new user. "
         "It is unclear whether the user has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16831,8 +16836,8 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new user. "
         "It is unclear whether the user has been created or not. "
         "Diagnostics: Internal Error.",
@@ -16896,24 +16901,24 @@ auth_settings_gmp (gvm_connection_t *connection,
         case 1:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Internal Error.",
             response_data);
@@ -17114,8 +17119,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a user. "
         "The user was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -17123,8 +17128,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a user. "
         "It is unclear whether the user has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -17132,8 +17137,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a user. "
         "It is unclear whether the user has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -17147,9 +17152,9 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       free_entity (entity);
 
       cmd_response_data_set_status_code (response_data, MHD_HTTP_UNAUTHORIZED);
-      return gsad_message (
-        credentials, "Authentication Required", __func__, __LINE__,
-        "Authentication method changed. Please login with ", response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "Authentication method changed. Please login with ",
+        response_data);
     }
   else
     html = response_from_entity (connection, credentials, params, entity,
@@ -17383,8 +17388,8 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving the auth settings. "
         "The settings were not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -17392,8 +17397,8 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving the auth settings. "
         "It is unclear whether the settings have been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -17401,8 +17406,8 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving the auth settings. "
         "It is unclear whether the settings have been saved or not. "
         "Diagnostics: Internal Error.",
@@ -17461,8 +17466,8 @@ get_settings_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the settings. "
         "The current list of settings is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -17475,8 +17480,8 @@ get_settings_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the settings. "
         "The current list of settings is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -17559,8 +17564,8 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -17569,8 +17574,8 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -17579,11 +17584,12 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while saving settings. "
-                           "It is unclear whether all the settings were saved. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while saving settings. "
+        "It is unclear whether all the settings were saved. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
   html = response_from_entity (connection, credentials, params, entity,
                                "Save Setting", response_data);
@@ -17607,12 +17613,13 @@ get_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting the "
-                           "dashboard settings"
-                           "Diagnostics: Failure to send command to manager "
-                           "daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the "
+        "dashboard settings"
+        "Diagnostics: Failure to send command to manager "
+        "daemon.",
+        response_data);
     }
 
   if (read_string_c (connection, &xml))
@@ -17620,12 +17627,13 @@ get_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting the "
-                           "dashboard settings"
-                           "Diagnostics: Failure to receive response from "
-                           "manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the "
+        "dashboard settings"
+        "Diagnostics: Failure to receive response from "
+        "manager daemon.",
+        response_data);
     }
 
   g_string_append (xml, "</get_settings>");
@@ -17657,8 +17665,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (name == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the wizard. "
         "Given name was invalid",
         response_data);
@@ -17680,8 +17688,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the wizard. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -17692,12 +17700,13 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting the"
-                           " wizard."
-                           "Diagnostics: Failure to receive response from"
-                           " manager daemon.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the"
+        " wizard."
+        "Diagnostics: Failure to receive response from"
+        " manager daemon.",
+        response_data);
     }
 
   /* Get the setting. */
@@ -17710,8 +17719,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the wizard. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -17722,8 +17731,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while the wizard. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -17787,8 +17796,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (name == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while trying to start a wizard. "
         "Diagnostics: Required parameter 'get_name' was NULL.",
         response_data);
@@ -17828,8 +17837,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while running a wizard. "
         "The wizard did not start. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -17837,8 +17846,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while running a wizard. "
         "It is unclear whether the wizard started or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -17846,11 +17855,12 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while running a wizard. "
-                           "It is unclear whether the wizard started or not. "
-                           "Diagnostics: Internal Error.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while running a wizard. "
+        "It is unclear whether the wizard started or not. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
 
   wizard_xml = g_strdup_printf ("<wizard><%s/>%s%s</wizard>", name,
@@ -17901,8 +17911,8 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (type == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting resources. "
         "The resources were not deleted. "
         "Diagnostics: Required parameter 'resource_type' was NULL.",
@@ -17947,8 +17957,8 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               g_free (extra_attribs);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while deleting resources. "
                 "The resources were not deleted. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -17962,8 +17972,8 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               g_free (extra_attribs);
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-              return gsad_message (
-                credentials, "Internal error", __func__, __LINE__,
+              return gsad_http_create_gsad_message (
+                credentials,
                 "An internal error occurred while deleting resources. "
                 "It is unclear whether the resources have been deleted or not. "
                 "Diagnostics: Failure to read response from manager daemon.",
@@ -17994,8 +18004,7 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: At least one DELETE command failed.",
         count, count > 1 ? "were" : "was");
 
-      html = gsad_message (credentials, "Error", __func__, __LINE__, msg,
-                           response_data);
+      html = gsad_http_create_gsad_message (credentials, msg, response_data);
       g_free (msg);
       return html;
     }
@@ -18108,8 +18117,8 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new host. "
         "No new host was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -18117,8 +18126,8 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new host. "
         "It is unclear whether the host has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18126,8 +18135,8 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new host. "
         "It is unclear whether the host has been created or not. "
         "Diagnostics: Internal Error.",
@@ -18168,10 +18177,11 @@ get_asset (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (params_value (params, "asset_name") && params_value (params, "asset_id"))
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __func__, __LINE__,
-                           "An internal error occurred while getting an asset. "
-                           "Diagnostics: Both ID and Name set.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting an asset. "
+        "Diagnostics: Both ID and Name set.",
+        response_data);
     }
 
   arguments = gmp_arguments_new ();
@@ -18278,8 +18288,8 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating an asset. "
         "No new asset was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -18287,8 +18297,8 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating an asset. "
         "It is unclear whether the asset has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18296,8 +18306,8 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating an asset. "
         "It is unclear whether the asset has been created or not. "
         "Diagnostics: Internal Error.",
@@ -18335,8 +18345,8 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   else
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting an asset. "
         "The asset was not deleted. "
         "Diagnostics: Required parameter was NULL.",
@@ -18365,8 +18375,8 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_free (resource_id);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting an asset. "
         "The asset is not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -18380,8 +18390,8 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting an asset. "
         "It is unclear whether the asset has been deleted or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -18474,8 +18484,8 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an asset. "
         "The asset was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -18483,8 +18493,8 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an asset. "
         "It is unclear whether the asset has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18492,8 +18502,8 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an asset. "
         "It is unclear whether the asset has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -18584,16 +18594,16 @@ create_ticket_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a ticket. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a ticket. "
         "It is unclear whether the ticket has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18601,8 +18611,8 @@ create_ticket_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a ticket. "
         "It is unclear whether the ticket has been created or not. "
         "Diagnostics: Internal Error.",
@@ -18664,16 +18674,16 @@ save_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a ticket. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a ticket. "
         "It is unclear whether the ticket has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18681,8 +18691,8 @@ save_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a ticket. "
         "It is unclear whether the ticket has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -18738,8 +18748,8 @@ get_timezones_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the timezones list. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -18753,8 +18763,8 @@ get_timezones_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the timezones list. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -18766,9 +18776,8 @@ get_timezones_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);
@@ -18894,16 +18903,16 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a TLS certificate. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a TLS certificate. "
         "It is unclear whether the TLS certificate has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18911,8 +18920,8 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a TLS certificate. "
         "It is unclear whether the TLS certificate has been created or not. "
         "Diagnostics: Internal Error.",
@@ -18979,16 +18988,16 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a TLS certificate. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a TLS certificate. "
         "It is unclear whether the TLS certificate has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -18996,8 +19005,8 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a TLS certificate. "
         "It is unclear whether the TLS certificate has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -19108,8 +19117,8 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_free (file_base64);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a license. "
         "The license remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -19118,8 +19127,8 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_free (file_base64);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a license. "
         "It is unclear whether the license has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -19128,8 +19137,8 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_free (file_base64);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving a license. "
         "It is unclear whether the license has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -19185,8 +19194,8 @@ change_password_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while changing the password. "
         "The password was not changed. "
         "Diagnostics: Manager closed connection during authenticate.",
@@ -19194,16 +19203,17 @@ change_password_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Invalid Password", __func__, __LINE__,
-                           "You tried to change your password, but the old"
-                           " password was not provided or was incorrect. "
-                           " Please enter the correct old password to proceed.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "You tried to change your password, but the old"
+        " password was not provided or was incorrect. "
+        " Please enter the correct old password to proceed.",
+        response_data);
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while changing the password. "
         "The password was not changed. "
         "Diagnostics: Internal Error.",
@@ -19223,8 +19233,8 @@ change_password_gmp (gvm_connection_t *connection,
       g_free (passwd_64);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while changing the password. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -19235,8 +19245,8 @@ change_password_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while changing the password. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -19326,9 +19336,9 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
   if (!id || strlen (id) == 0)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Missing installer ID", __func__, __LINE__,
-        "The 'agent_installer_id' parameter is required.", response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "The 'agent_installer_id' parameter is required.",
+        response_data);
     }
 
   // Send request
@@ -19338,9 +19348,9 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "GMP send failed", __func__, __LINE__,
-                           "Failed to send GMP command to retrieve installer.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "Failed to send GMP command to retrieve installer.",
+        response_data);
     }
 
   // Parse response
@@ -19348,9 +19358,9 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "GMP receive failed", __func__, __LINE__,
-        "Failed to receive installer file response.", response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "Failed to receive installer file response.",
+        response_data);
     }
 
   if (gmp_success (entity) != 1)
@@ -19359,9 +19369,8 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
       free_entity (entity);
       return message;
     }
@@ -19373,9 +19382,8 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
       free_entity (entity);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "No installer file", __func__, __LINE__,
-                           "No agent installer content was returned.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "No agent installer content was returned.", response_data);
     }
 
   format_entity = entity_child (file_entity, "file_extension");
@@ -19532,9 +19540,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (!agent_ids)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Missing agent IDs", __func__, __LINE__,
-                           "The 'agent_ids' parameter is required.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "The 'agent_ids' parameter is required.", response_data);
     }
 
   if (params_given (params, "update_to_latest"))
@@ -19646,8 +19653,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent list. "
         "The agents list was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -19655,8 +19662,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent list. "
         "It is unclear whether the agents list has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -19664,8 +19671,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agents list. "
         "It is unclear whether the agent list has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -19733,9 +19740,9 @@ modify_agent_control_scan_config_gmp (gvm_connection_t *connection,
   if (!agent_control_id)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (
-        credentials, "Missing agent control ID", __func__, __LINE__,
-        "The 'agent_control_id' parameter is required.", response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "The 'agent_control_id' parameter is required.",
+        response_data);
     }
 
   char *name;
@@ -19805,8 +19812,8 @@ modify_agent_control_scan_config_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying the agent control "
         "scan config. The scan config was not modified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -19814,8 +19821,8 @@ modify_agent_control_scan_config_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying the agent control "
         "scan config. It is unclear whether the scan config has been modified "
         "or not. "
@@ -19824,8 +19831,8 @@ modify_agent_control_scan_config_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying the agent control "
         "scan config. It is unclear whether the scan config has been modified "
         "or not. "
@@ -19866,9 +19873,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (!agent_ids)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Missing agent IDs", __func__, __LINE__,
-                           "The 'agent_ids' parameter is required.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "The 'agent_ids' parameter is required.", response_data);
     }
 
   agents_element = g_string_new ("<agents>");
@@ -19900,8 +19906,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting an agent list. "
         "The agents list was not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -19909,8 +19915,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting an agent list. "
         "It is unclear whether the agents list has been deleted or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -19918,8 +19924,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while deleting an agents list. "
         "It is unclear whether the agent list has been deleted or not. "
         "Diagnostics: Internal Error.",
@@ -20014,9 +20020,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
   if (!agent_ids && !copy)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Missing agent IDs", __func__, __LINE__,
-                           "The 'agent_ids' parameter is required.",
-                           response_data);
+      return gsad_http_create_gsad_message (
+        credentials, "The 'agent_ids' parameter is required.", response_data);
     }
 
   if (agent_ids)
@@ -20048,8 +20053,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new agent group. "
         "No new agent group created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -20057,8 +20062,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new agent group. "
         "It is unclear whether the agent group has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -20066,8 +20071,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new agent group. "
         "It is unclear whether the agent group has been created or not. "
         "Diagnostics: Internal Error.",
@@ -20151,8 +20156,8 @@ save_agent_group_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent group. "
         "The agent group was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -20160,8 +20165,8 @@ save_agent_group_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent group. "
         "It is unclear whether the agent group has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -20169,8 +20174,8 @@ save_agent_group_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while saving an agent group. "
         "It is unclear whether the agent group has been created or not. "
         "Diagnostics: Internal Error.",
@@ -20412,8 +20417,8 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
     case 1:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new OCI image target. "
         "No new target was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -20421,8 +20426,8 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
     case 2:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new OCI image target. "
         "It is unclear whether the target has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -20430,8 +20435,8 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while creating a new OCI image target. "
         "It is unclear whether the target has been created or not. "
         "Diagnostics: Internal Error.",
@@ -20522,8 +20527,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
         case 1:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving an OCI image target. "
             "The target remains the same. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -20531,8 +20536,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
         case 2:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving an OCI image target. "
             "It is unclear whether the target has been saved or not. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -20540,8 +20545,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
         default:
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
+          return gsad_http_create_gsad_message (
+            credentials,
             "An internal error occurred while saving an OCI image target. "
             "It is unclear whether the target has been saved or not. "
             "Diagnostics: Internal Error.",
@@ -20626,8 +20631,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying an OCI image target. "
         "No target was modified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -20639,8 +20644,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while modifying an OCI image target. "
         "It is unclear whether the target has been modified or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -20685,8 +20690,8 @@ get_capabilities_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the user credentials. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -20701,8 +20706,8 @@ get_capabilities_gmp (gvm_connection_t *connection,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the user credentials. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -20714,9 +20719,8 @@ get_capabilities_gmp (gvm_connection_t *connection,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);
@@ -20744,8 +20748,8 @@ get_features_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the features list. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -20760,8 +20764,8 @@ get_features_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (
-        credentials, "Internal error", __func__, __LINE__,
+      return gsad_http_create_gsad_message (
+        credentials,
         "An internal error occurred while getting the feature list. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -20773,9 +20777,8 @@ get_features_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
       set_http_status_from_entity (entity, response_data);
 
-      message =
-        gsad_message (credentials, "Error", __func__, __LINE__,
-                      entity_attribute (entity, "status_text"), response_data);
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
       free_entity (entity);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -280,7 +280,7 @@ static char *
 envelope_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               params_t *params, gchar *xml, cmd_response_data_t *response_data)
 {
-  return gsad_envelope (credentials, xml, response_data);
+  return gsad_http_create_envelope (credentials, xml, response_data);
 }
 
 /**
@@ -21060,10 +21060,10 @@ login (gsad_http_connection_t *con, params_t *params,
           gsad_credentials_set_user (credentials, user);
           gsad_credentials_set_jwt (credentials, jwt);
 
-          // xml must not be NULL: gsad_envelope() expects a valid string
-          // and passing NULL would trigger a GLib critical
-          gchar *data =
-            gsad_envelope (credentials, g_strdup (""), response_data);
+          // xml must not be NULL: gsad_http_create_envelope() expects a valid
+          // string and passing NULL would trigger a GLib critical
+          gchar *data = gsad_http_create_envelope (credentials, g_strdup (""),
+                                                   response_data);
 
           ret = gsad_http_create_response (con, data, response_data,
                                            gsad_user_get_cookie (user));

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -974,8 +974,8 @@ serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,
  * @return Enveloped GMP XML.
  */
 char *
-gsad_envelope (gsad_credentials_t *credentials, gchar *xml,
-               cmd_response_data_t *response_data)
+gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
+                           cmd_response_data_t *response_data)
 {
   assert (credentials);
 
@@ -1045,7 +1045,8 @@ gsad_message (gsad_credentials_t *credentials, const char *title,
 
   if (credentials)
     {
-      return gsad_envelope (credentials, gsad_response, response_data);
+      return gsad_http_create_envelope (credentials, gsad_response,
+                                        response_data);
     }
 
   gchar *envelope = g_strdup_printf ("<envelope>"

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -642,8 +642,7 @@ gsad_http_send_reauthentication (gsad_http_connection_t *connection,
   cmd_response_data_t *response_data = cmd_response_data_new ();
   cmd_response_data_set_status_code (response_data, http_status_code);
 
-  gchar *xml = gsad_message (NULL, "Authentication required", __func__,
-                             __LINE__, msg, response_data);
+  gchar *xml = gsad_http_create_gsad_message (NULL, msg, response_data);
 
   return gsad_http_create_response (connection, xml, response_data, REMOVE_SID);
 }
@@ -1020,28 +1019,23 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
 }
 
 /**
- * @brief Handles fatal errors.
+ * @brief Create a <gsad_message> response XML
  *
- * @todo Make it accept formatted strings.
- *
- * @param[in]  credentials     User authentication information.
- * @param[in]  title           The title for the message.
- * @param[in]  function        The function in which the error occurred.
- * @param[in]  line            The line number at which the error occurred.
- * @param[in]  msg             The response message.
+ * @param[in]  credentials     User authentication information, if available.
+ * @param[in]  message         The response message.
  * @param[out] response_data   Extra data return for the HTTP response.
  *
  * @return An XML document as a newly allocated string.
  */
 gchar *
-gsad_message (gsad_credentials_t *credentials, const char *title,
-              const char *function, int line, const char *msg,
-              cmd_response_data_t *response_data)
+gsad_http_create_gsad_message (gsad_credentials_t *credentials,
+                               const char *message,
+                               cmd_response_data_t *response_data)
 {
   gchar *gsad_response = g_markup_printf_escaped ("<gsad_response>"
                                                   "<message>%s</message>"
                                                   "</gsad_response>",
-                                                  msg ? msg : "");
+                                                  message ? message : "");
 
   if (credentials)
     {

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -198,6 +198,7 @@ gsad_message (gsad_credentials_t *, const gchar *, const gchar *, int,
               const gchar *, cmd_response_data_t *);
 
 gchar *
-gsad_envelope (gsad_credentials_t *, gchar *, cmd_response_data_t *);
+gsad_http_create_envelope (gsad_credentials_t *, gchar *,
+                           cmd_response_data_t *);
 
 #endif /* _GSAD_HTTP_H */

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -194,8 +194,8 @@ exec_gmp_post (gsad_http_connection_t *connection,
                gsad_connection_info_t *con_info, const gchar *client_address);
 
 gchar *
-gsad_message (gsad_credentials_t *, const gchar *, const gchar *, int,
-              const gchar *, cmd_response_data_t *);
+gsad_http_create_gsad_message (gsad_credentials_t *, const gchar *,
+                               cmd_response_data_t *);
 
 gchar *
 gsad_http_create_envelope (gsad_credentials_t *, gchar *,

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -509,21 +509,22 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
                   slave_id);
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
-          res =
-            gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not receive the system report. ",
-                          response_data);
+          res = gsad_http_create_gsad_message (
+            credentials,
+            "An internal error occurred. "
+            "Diagnostics: Could not receive the system report. ",
+            response_data);
         }
       break;
     case 1: /* manager closed connection */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Failure to connect to manager daemon. "
-                          "Manager daemon doesn't respond.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Failure to connect to manager daemon. "
+        "Manager daemon doesn't respond.",
+        response_data);
       break;
     case 2: /* authentication failed */
       cmd_response_data_free (response_data);
@@ -535,29 +536,32 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
     case 3: /* timeout */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Failure to connect to manager daemon. "
-                          "Timeout while waiting for manager response.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Failure to connect to manager daemon. "
+        "Timeout while waiting for manager response.",
+        response_data);
       break;
     case 4: /* failed to connect to manager */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Failure to connect to manager daemon. "
-                          "Could not open a connection.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Failure to connect to manager daemon. "
+        "Could not open a connection.",
+        response_data);
       break;
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Failure to connect to manager daemon. "
-                          "Unknown error.",
-                          response_data);
+      res = gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred. "
+        "Diagnostics: Failure to connect to manager daemon. "
+        "Unknown error.",
+        response_data);
       break;
     }
 


### PR DESCRIPTION
## What

Cleanup the gsad http module

* Rename `gsad_message` to `gsad_http_create_gsad_message` and remove unused arguments
* Rename `gsad_envelope` to `gsad_http_create_envelope`

## Why

Make function naming in gsad http module more consistent.


