### PR TITLE
HTTP Credential Setup

### DIFF
--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -172,8 +172,8 @@ gsad_http_get_session_cookie_from_connection (
  * that occurred while getting the user information.
  */
 static int
-get_user_from_connection (gsad_http_connection_t *connection,
-                          gsad_user_t **user)
+gsad_http_get_user_from_connection (gsad_http_connection_t *connection,
+                                    gsad_user_t **user)
 {
   const gchar *cookie;
   const gchar *token;
@@ -229,7 +229,7 @@ gsad_http_handle_get_user (gsad_http_handler_t *handler_next,
                            gsad_connection_info_t *con_info, void *data)
 {
   gsad_user_t *user = NULL;
-  get_user_from_connection (connection, &user);
+  gsad_http_get_user_from_connection (connection, &user);
   return gsad_http_handler_call (handler_next, connection, con_info, user);
 }
 
@@ -265,7 +265,7 @@ gsad_http_handle_setup_user (gsad_http_handler_t *handler_next,
 
   gsad_user_t *user;
 
-  ret = get_user_from_connection (connection, &user);
+  ret = gsad_http_get_user_from_connection (connection, &user);
 
   if (ret == USER_GMP_DOWN)
     {

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -132,6 +132,26 @@ gsad_http_handle_invalid_method (gsad_http_handler_t *handler_next,
 }
 
 /**
+ * @brief Internal function for getting the JWT token from the connection.
+ *
+ * @param[in] connection The HTTP connection for which the request was made
+ *
+ * @return The JWT from the connection or NULL if the token is not present or
+ * invalid
+ */
+static const gchar *
+gsad_http_get_jwt_from_connection (gsad_http_connection_t *connection)
+{
+  const gchar *bearer =
+    MHD_lookup_connection_value (connection, MHD_HEADER_KIND, "Authorization");
+  if (bearer && g_str_has_prefix (bearer, "Bearer "))
+    {
+      return bearer + strlen ("Bearer ");
+    }
+  return NULL;
+}
+
+/**
  * @brief Internal function for getting the token from the connection.
  *
  * @param[in] connection The HTTP connection for which the request was made

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -132,7 +132,38 @@ gsad_http_handle_invalid_method (gsad_http_handler_t *handler_next,
 }
 
 /**
- * Internal function for getting user information from the connection.
+ * @brief Internal function for getting the token from the connection.
+ *
+ * @param[in] connection The HTTP connection for which the request was made
+ *
+ * @return The token from the connection or NULL if the token is not present or
+ * invalid
+ */
+static const gchar *
+gsad_http_get_token_from_connection (gsad_http_connection_t *connection)
+{
+  return MHD_lookup_connection_value (connection, MHD_GET_ARGUMENT_KIND,
+                                      "token");
+}
+
+/**
+ * @brief Internal function for getting the session cookie from the connection.
+ *
+ * @param[in] connection The HTTP connection for which the request was made
+ *
+ * @return The session cookie from the connection or NULL if the session cookie
+ * is not present or invalid
+ */
+static const gchar *
+gsad_http_get_session_cookie_from_connection (
+  gsad_http_connection_t *connection)
+{
+  return MHD_lookup_connection_value (connection, MHD_COOKIE_KIND,
+                                      SID_COOKIE_NAME);
+}
+
+/**
+ * @brief Internal function for getting user information from the connection.
  *
  * @param[in] connection The HTTP connection for which the request was made
  * @param[out] user The user information retrieved from the connection
@@ -148,8 +179,7 @@ get_user_from_connection (gsad_http_connection_t *connection,
   const gchar *token;
   gchar client_address[INET6_ADDRSTRLEN];
 
-  token =
-    MHD_lookup_connection_value (connection, MHD_GET_ARGUMENT_KIND, "token");
+  token = gsad_http_get_token_from_connection (connection);
   if (token == NULL)
     {
       return USER_BAD_MISSING_TOKEN;
@@ -160,9 +190,7 @@ get_user_from_connection (gsad_http_connection_t *connection,
       return USER_BAD_MISSING_TOKEN;
     }
 
-  cookie =
-    MHD_lookup_connection_value (connection, MHD_COOKIE_KIND, SID_COOKIE_NAME);
-
+  cookie = gsad_http_get_session_cookie_from_connection (connection);
   if (gvm_validate (http_validator, "token", cookie))
     {
       return USER_BAD_MISSING_COOKIE;
@@ -413,8 +441,7 @@ gsad_http_handle_gmp_post (gsad_http_handler_t *handler_next,
   const gchar *sid, *accept_language;
   char client_address[INET6_ADDRSTRLEN];
 
-  sid =
-    MHD_lookup_connection_value (connection, MHD_COOKIE_KIND, SID_COOKIE_NAME);
+  sid = gsad_http_get_session_cookie_from_connection (connection);
 
   if (gvm_validate (http_validator, "token", sid))
     gsad_connection_info_set_cookie (con_info, NULL);

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -359,11 +359,11 @@ gsad_http_handle_setup_credentials (gsad_http_handler_t *handler_next,
                                     void *data)
 {
   gsad_user_t *user = (gsad_user_t *) data;
-  gsad_credentials_t *credentials = gsad_credentials_new ();
-  const gchar *jwt_token = user ? gsad_user_get_jwt (user) : NULL;
+  const gchar *jwt = gsad_http_get_jwt_from_connection (connection);
 
+  gsad_credentials_t *credentials = gsad_credentials_new ();
   gsad_credentials_set_user (credentials, user);
-  gsad_credentials_set_jwt (credentials, jwt_token);
+  gsad_credentials_set_jwt (credentials, jwt);
   gsad_user_free (user);
 
   return gsad_http_handler_call (handler_next, connection, con_info,

--- a/src/gsad_manager.c
+++ b/src/gsad_manager.c
@@ -171,9 +171,22 @@ int
 gsad_manager_connect_with_credentials (gvm_connection_t *connection,
                                        gsad_credentials_t *credentials)
 {
+  const gchar *jwt = gsad_credentials_get_jwt (credentials);
+  if (jwt)
+    {
+      return gsad_manager_connect_with_jwt (connection, jwt);
+    }
+
   gsad_user_t *user = gsad_credentials_get_user (credentials);
-  return gsad_manager_connect_with_username_password (
-    connection, gsad_user_get_username (user), gsad_user_get_password (user));
+  if (user)
+    {
+      return gsad_manager_connect_with_username_password (
+        connection, gsad_user_get_username (user),
+        gsad_user_get_password (user));
+    }
+  g_critical ("Credentials must have either a JWT token or a user with "
+              "username and password");
+  return -1;
 }
 
 /**

--- a/src/gsad_manager.c
+++ b/src/gsad_manager.c
@@ -89,6 +89,7 @@ gmp_authenticate_with_xml (gvm_connection_t *connection, const gchar *xml)
 static int
 gmp_authenticate_with_jwt (gvm_connection_t *connection, const gchar *token)
 {
+  g_debug ("Authenticating with JWT");
   gchar *xml = g_markup_printf_escaped ("<token>%s</token>", token);
   int ret = gmp_authenticate_with_xml (connection, xml);
   g_free (xml);
@@ -109,6 +110,7 @@ gmp_authenticate_with_username_password (gvm_connection_t *connection,
                                          const gchar *username,
                                          const gchar *password)
 {
+  g_debug ("Authenticating with username and password");
   gchar *xml = g_markup_printf_escaped (
     "<username>%s</username><password>%s</password>", username, password);
   int ret = gmp_authenticate_with_xml (connection, xml);

--- a/src/gsad_manager.h
+++ b/src/gsad_manager.h
@@ -26,6 +26,10 @@ gsad_manager_connect_with_username_password (gvm_connection_t *connection,
                                              const gchar *password);
 
 int
+gsad_manager_connect_with_jwt (gvm_connection_t *connection,
+                               const gchar *token);
+
+int
 gsad_manager_connect_with_auth_opts (gvm_connection_t *connection,
                                      gmp_authenticate_info_opts_t auth_opts);
 


### PR DESCRIPTION
## What

Allow to use JWT for connecting to gvmd.

Retrieve the JWT from the Authorization header and use it to connect to gvmd. Otherwise fallback to username+password combination from the current user in the session.

## Why

Initial setup for JWT authorization support in gsad.

## References

https://jira.greenbone.net/browse/GEA-1668


