### PR TITLE
gsad command response data

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,7 @@ add_executable(
   gsad.c
   gsad_args.c
   gsad_base.c
-  gsad_cmd.c
+  gsad_command_response_data.c
   gsad_connection_info.c
   gsad_credentials.c
   gsad_gmp.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,6 +254,7 @@ if(BUILD_TESTING)
     gsad_settings.c
     gsad_user.c
   )
+  add_unit_test(gsad-command-response-data)
   add_custom_target(
     tests
     DEPENDS
@@ -270,6 +271,7 @@ if(BUILD_TESTING)
       gsad-user-test
       gsad-session-test
       gsad-user-session-test
+      gsad-command-response-data-test
   )
 endif(BUILD_TESTING)
 

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -183,7 +183,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gchar *res = NULL, *new_sid = NULL;
   const gchar *cmd, *caller;
   gvm_connection_t connection;
-  gsad_command_response_data_t *response_data = cmd_response_data_new ();
+  gsad_command_response_data_t *response_data =
+    gsad_command_response_data_new ();
 
   params_t *params = gsad_connection_info_get_params (con_info);
   params_mhd_validate (params);
@@ -257,7 +258,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
       /* @todo Validate caller. */
 
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
 
       return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
                                               SESSION_EXPIRED);
@@ -265,7 +266,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   if (ret == USER_BAD_MISSING_COOKIE || ret == USER_IP_ADDRESS_MISSMATCH)
     {
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
 
       return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
                                               BAD_MISSING_COOKIE);
@@ -273,7 +274,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   if (ret == USER_GMP_DOWN)
     {
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
 
       return gsad_http_send_reauthentication (con, MHD_HTTP_SERVICE_UNAVAILABLE,
                                               GMP_SERVICE_DOWN);
@@ -318,7 +319,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         response_data);
       break;
     case 2: /* auth failed */
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
       return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
                                               LOGIN_FAILED);
     case 3: /* timeout */
@@ -780,7 +781,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gchar *encoding;
 
   validator = gsad_get_validator ();
-  response_data = cmd_response_data_new ();
+  response_data = gsad_command_response_data_new ();
 
   cmd = params_value (params, "cmd");
 
@@ -833,7 +834,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         response_data);
       break;
     case 2: /* auth failed */
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
       return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
                                               LOGIN_FAILED);
     case 3: /* timeout */

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -183,7 +183,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gchar *res = NULL, *new_sid = NULL;
   const gchar *cmd, *caller;
   gvm_connection_t connection;
-  cmd_response_data_t *response_data = cmd_response_data_new ();
+  gsad_command_response_data_t *response_data = cmd_response_data_new ();
 
   params_t *params = gsad_connection_info_get_params (con_info);
   params_mhd_validate (params);
@@ -773,7 +773,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gchar *res = NULL, *comp = NULL;
   gsize res_len = 0;
   gsad_http_response_t *response;
-  cmd_response_data_t *response_data;
+  gsad_command_response_data_t *response_data;
   pthread_t watch_thread;
   connection_watcher_data_t *watcher_data;
   validator_t validator;

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -964,7 +964,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   {
     gsad_command_response_data_set_content_type (response_data,
                                                  GSAD_CONTENT_TYPE_APP_KEY);
-    cmd_response_data_set_content_disposition (
+    gsad_command_response_data_set_content_disposition (
       response_data, g_strdup_printf ("attachment; filename=ssl-cert-%s.pem",
                                       params_value (params, "name")));
 
@@ -975,7 +975,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   {
     gsad_command_response_data_set_content_type (response_data,
                                                  GSAD_CONTENT_TYPE_APP_KEY);
-    cmd_response_data_set_content_disposition (
+    gsad_command_response_data_set_content_disposition (
       response_data,
       g_strdup_printf ("attachment; filename=scanner-ca-pub-%s.pem",
                        params_value (params, "scanner_id")));
@@ -986,7 +986,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   {
     gsad_command_response_data_set_content_type (response_data,
                                                  GSAD_CONTENT_TYPE_APP_KEY);
-    cmd_response_data_set_content_disposition (
+    gsad_command_response_data_set_content_disposition (
       response_data,
       g_strdup_printf ("attachment; filename=scanner-key-pub-%s.pem",
                        params_value (params, "scanner_id")));

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -193,7 +193,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   if (!cmd)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
 
       res = gsad_http_create_gsad_message (
         credentials,
@@ -214,7 +215,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   if (params_value (params, "token") == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
 
       if (params_given (params, "token") == 0)
         res = gsad_http_create_gsad_message (
@@ -237,7 +239,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
                                 &user);
   if (ret == USER_BAD_TOKEN)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       res = gsad_http_create_gsad_message (
         NULL,
         "An internal error occurred inside GSA daemon. "
@@ -309,8 +312,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     case 0:
       break;
     case 1: /* manager closed connection */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -323,8 +326,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
                                               LOGIN_FAILED);
     case 3: /* timeout */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -333,8 +336,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         response_data);
       break;
     case 4: /* can't connect to manager */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_SERVICE_UNAVAILABLE);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_SERVICE_UNAVAILABLE);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -343,8 +346,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         response_data);
       break;
     default: /* unknown error */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -487,7 +490,8 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (verify_scanner)
   else
   {
-    cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_BAD_REQUEST);
     res = gsad_http_create_gsad_message (
       credentials,
       "An internal error occurred inside GSA daemon. "
@@ -794,7 +798,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     }
   else
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred inside GSA daemon. "
@@ -824,8 +829,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     case 0:
       break;
     case 1: /* manager closed connection */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -838,8 +843,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
                                               LOGIN_FAILED);
     case 3: /* timeout */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -848,8 +853,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         response_data);
       break;
     case 4: /* can't connect to manager */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_SERVICE_UNAVAILABLE);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_SERVICE_UNAVAILABLE);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -858,8 +863,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         response_data);
       break;
     default: /* unknown error */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -1082,7 +1087,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   else
   {
-    cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_BAD_REQUEST);
     res = gsad_http_create_gsad_message (
       credentials,
       "An internal error occurred inside GSA daemon. "

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -957,8 +957,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   else if (!strcmp (cmd, "download_ssl_cert"))
   {
-    cmd_response_data_set_content_type (response_data,
-                                        GSAD_CONTENT_TYPE_APP_KEY);
+    gsad_command_response_data_set_content_type (response_data,
+                                                 GSAD_CONTENT_TYPE_APP_KEY);
     cmd_response_data_set_content_disposition (
       response_data, g_strdup_printf ("attachment; filename=ssl-cert-%s.pem",
                                       params_value (params, "name")));
@@ -968,8 +968,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   else if (!strcmp (cmd, "download_ca_pub"))
   {
-    cmd_response_data_set_content_type (response_data,
-                                        GSAD_CONTENT_TYPE_APP_KEY);
+    gsad_command_response_data_set_content_type (response_data,
+                                                 GSAD_CONTENT_TYPE_APP_KEY);
     cmd_response_data_set_content_disposition (
       response_data,
       g_strdup_printf ("attachment; filename=scanner-ca-pub-%s.pem",
@@ -979,8 +979,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   else if (!strcmp (cmd, "download_key_pub"))
   {
-    cmd_response_data_set_content_type (response_data,
-                                        GSAD_CONTENT_TYPE_APP_KEY);
+    gsad_command_response_data_set_content_type (response_data,
+                                                 GSAD_CONTENT_TYPE_APP_KEY);
     cmd_response_data_set_content_disposition (
       response_data,
       g_strdup_printf ("attachment; filename=scanner-key-pub-%s.pem",

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1096,7 +1096,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       response_data);
   }
 
-  res_len = cmd_response_data_get_content_length (response_data);
+  res_len = gsad_command_response_data_get_content_length (response_data);
 
   if (res_len == 0)
     res_len = strlen (res);

--- a/src/gsad_base.h
+++ b/src/gsad_base.h
@@ -11,7 +11,7 @@
 #ifndef _GSAD_BASE_H
 #define _GSAD_BASE_H
 
-#include "gsad_cmd.h"  /* for cmd_response_data_t */
+#include "gsad_cmd.h"  /* for gsad_command_response_data_t */
 #include "gsad_user.h" /* for gsad_credentials_t */
 
 #include <glib.h>

--- a/src/gsad_base.h
+++ b/src/gsad_base.h
@@ -11,8 +11,8 @@
 #ifndef _GSAD_BASE_H
 #define _GSAD_BASE_H
 
-#include "gsad_cmd.h"  /* for gsad_command_response_data_t */
-#include "gsad_user.h" /* for gsad_credentials_t */
+#include "gsad_command_response_data.h" /* for gsad_command_response_data_t */
+#include "gsad_user.h"                  /* for gsad_credentials_t */
 
 #include <glib.h>
 #include <sys/time.h>

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -31,7 +31,7 @@ struct gsad_command_response_data
  * @param[in]  data  The gsad_commad_response_data_t struct to initialize
  */
 static void
-cmd_response_data_init (gsad_command_response_data_t *data)
+gsad_command_response_data_init (gsad_command_response_data_t *data)
 {
   data->allow_caching = FALSE;
   data->http_status_code = MHD_HTTP_OK;
@@ -48,11 +48,11 @@ cmd_response_data_init (gsad_command_response_data_t *data)
  * @return Pointer to the newly allocated gsad_command_response_data_t struct
  */
 gsad_command_response_data_t *
-cmd_response_data_new ()
+gsad_command_response_data_new ()
 {
   gsad_command_response_data_t *data =
     g_malloc0 (sizeof (gsad_command_response_data_t));
-  cmd_response_data_init (data);
+  gsad_command_response_data_init (data);
   return data;
 }
 
@@ -65,7 +65,7 @@ cmd_response_data_new ()
  * @param[in] data The gsad_commad_response_data_t struct to free
  */
 void
-cmd_response_data_free (gsad_command_response_data_t *data)
+gsad_command_response_data_free (gsad_command_response_data_t *data)
 {
   if (!data)
     {

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -72,16 +72,8 @@ gsad_command_response_data_free (gsad_command_response_data_t *data)
       return;
     }
 
-  if (data->content_disposition)
-    {
-      g_free (data->content_disposition);
-    }
-
-  if (data->content_type_string)
-    {
-      g_free (data->content_type_string);
-    }
-
+  g_free (data->content_disposition);
+  g_free (data->content_type_string);
   g_free (data);
 }
 

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -110,8 +110,8 @@ gsad_command_response_data_is_allow_caching (gsad_command_response_data_t *data)
  * @param[in]  content_type  Content Type to set
  */
 void
-cmd_response_data_set_content_type (gsad_command_response_data_t *data,
-                                    content_type_t content_type)
+gsad_command_response_data_set_content_type (gsad_command_response_data_t *data,
+                                             content_type_t content_type)
 {
   data->content_type = content_type;
 }
@@ -124,7 +124,7 @@ cmd_response_data_set_content_type (gsad_command_response_data_t *data,
  * @return The content type
  */
 content_type_t
-cmd_response_data_get_content_type (gsad_command_response_data_t *data)
+gsad_command_response_data_get_content_type (gsad_command_response_data_t *data)
 {
   return data->content_type;
 }
@@ -217,8 +217,8 @@ cmd_response_data_get_content_disposition (gsad_command_response_data_t *data)
  * @param[in]  content_type_string   Content type as string
  */
 void
-cmd_response_data_set_content_type_string (gsad_command_response_data_t *data,
-                                           gchar *content_type_string)
+gsad_command_response_data_set_content_type_string (
+  gsad_command_response_data_t *data, gchar *content_type_string)
 {
   data->content_type = GSAD_CONTENT_TYPE_STRING;
   data->content_type_string = content_type_string;
@@ -231,7 +231,8 @@ cmd_response_data_set_content_type_string (gsad_command_response_data_t *data,
  * @return Content type string if set
  */
 const gchar *
-cmd_response_data_get_content_type_string (gsad_command_response_data_t *data)
+gsad_command_response_data_get_content_type_string (
+  gsad_command_response_data_t *data)
 {
   return data->content_type_string;
 }

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -11,7 +11,6 @@
 #include "gsad_cmd.h"
 
 #include <microhttpd.h> /* for MHD_HTTP_OK */
-#include <string.h>     /* for memset */
 
 /**
  * @brief Response information for commands.

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -26,12 +26,12 @@ struct gsad_command_response_data
 };
 
 /**
- * @brief Initializes a cmd_response_data_t struct.
+ * @brief Initializes a gsad_commad_response_data_t struct.
  *
- * @param[in]  data  The cmd_response_data_t struct to initialize
+ * @param[in]  data  The gsad_commad_response_data_t struct to initialize
  */
 static void
-cmd_response_data_init (cmd_response_data_t *data)
+cmd_response_data_init (gsad_command_response_data_t *data)
 {
   data->allow_caching = FALSE;
   data->http_status_code = MHD_HTTP_OK;
@@ -42,28 +42,30 @@ cmd_response_data_init (cmd_response_data_t *data)
 }
 
 /**
- * @brief Allocates memory for a cmd_response_data_t sturct and initializes it
+ * @brief Allocates memory for a gsad_commad_response_data_t sturct and
+ * initializes it
  *
- * @return Pointer to the newly allocated cmd_response_data_t struct
+ * @return Pointer to the newly allocated gsad_command_response_data_t struct
  */
-cmd_response_data_t *
+gsad_command_response_data_t *
 cmd_response_data_new ()
 {
-  cmd_response_data_t *data = g_malloc0 (sizeof (cmd_response_data_t));
+  gsad_command_response_data_t *data =
+    g_malloc0 (sizeof (gsad_command_response_data_t));
   cmd_response_data_init (data);
   return data;
 }
 
 /**
- * @brief Frees the memory of a cmd_response_data_t struct
+ * @brief Frees the memory of a gsad_commad_response_data_t struct
  *
  * If content_disposition of data is not NULL the content_disposition is also
  * being freed.
  *
- * @param[in] data The cmd_response_data_t struct to free
+ * @param[in] data The gsad_commad_response_data_t struct to free
  */
 void
-cmd_response_data_free (cmd_response_data_t *data)
+cmd_response_data_free (gsad_command_response_data_t *data)
 {
   if (!data)
     {
@@ -84,131 +86,131 @@ cmd_response_data_free (cmd_response_data_t *data)
 }
 
 /**
- * @brief Set allow_caching flag of cmd_response_data_t struct
+ * @brief Set allow_caching flag of gsad_commad_response_data_t struct
  *
  * @param[in]  data           Command response data struct
  * @param[in]  allow_caching  allow_caching flag to set
  */
 void
-cmd_response_data_set_allow_caching (cmd_response_data_t *data,
+cmd_response_data_set_allow_caching (gsad_command_response_data_t *data,
                                      gboolean allow_caching)
 {
   data->allow_caching = (allow_caching != FALSE);
 }
 
 /**
- * @brief Get allow_caching flag of cmd_response_data_t struct
+ * @brief Get allow_caching flag of gsad_command_response_data_t struct
  *
  * @param[in]  data  Command response data struct
  *
  * @return The allow_caching flag
  */
 gboolean
-cmd_response_data_is_allow_caching (cmd_response_data_t *data)
+cmd_response_data_is_allow_caching (gsad_command_response_data_t *data)
 {
   return data->allow_caching;
 }
 
 /**
- * @brief Set content type of cmd_response_data_t struct
+ * @brief Set content type of gsad_command_response_data_t struct
  *
  * @param[in]  data          Command response data struct
  * @param[in]  content_type  Content Type to set
  */
 void
-cmd_response_data_set_content_type (cmd_response_data_t *data,
+cmd_response_data_set_content_type (gsad_command_response_data_t *data,
                                     content_type_t content_type)
 {
   data->content_type = content_type;
 }
 
 /**
- * @brief Get content type of cmd_response_data_t struct
+ * @brief Get content type of gsad_command_response_data_t struct
  *
  * @param[in]  data  Command response data struct
  *
  * @return The content type
  */
 content_type_t
-cmd_response_data_get_content_type (cmd_response_data_t *data)
+cmd_response_data_get_content_type (gsad_command_response_data_t *data)
 {
   return data->content_type;
 }
 
 /**
- * @brief Set status code of cmd_response_data_t struct
+ * @brief Set status code of gsad_command_response_data_t struct
  *
  * @param[in]  data              Command response data struct
  * @param[in]  http_status_code  HTTP status code
  */
 void
-cmd_response_data_set_status_code (cmd_response_data_t *data,
+cmd_response_data_set_status_code (gsad_command_response_data_t *data,
                                    int http_status_code)
 {
   data->http_status_code = http_status_code;
 }
 
 /**
- * @brief Get http status code of cmd_response_data_t struct
+ * @brief Get http status code of gsad_command_response_data_t struct
  *
  * @param[in]  data  Command response data struct
  *
  * @return  HTTP status code
  */
 int
-cmd_response_data_get_status_code (cmd_response_data_t *data)
+cmd_response_data_get_status_code (gsad_command_response_data_t *data)
 {
   return data->http_status_code;
 }
 
 /**
- * @brief Set response content length of cmd_response_data_t struct
+ * @brief Set response content length of gsad_command_response_data_t struct
  *
  * @param[in]  data            Command response data struct
  * @param[in]  content_length  Content length of the response
  */
 void
-cmd_response_data_set_content_length (cmd_response_data_t *data,
+cmd_response_data_set_content_length (gsad_command_response_data_t *data,
                                       gsize content_length)
 {
   data->content_length = content_length;
 }
 
 /**
- * @brief Get response content length of cmd_response_data_t struct
+ * @brief Get response content length of gsad_command_response_data_t struct
  *
  * @param[in]  data  Command response data struct
  *
  * @return Content length of the response
  */
 gsize
-cmd_response_data_get_content_length (cmd_response_data_t *data)
+cmd_response_data_get_content_length (gsad_command_response_data_t *data)
 {
   return data->content_length;
 }
 
 /**
- * @brief Set content disposition of cmd_response_data_t struct
+ * @brief Set content disposition of gsad_command_response_data_t struct
  *
  * @param[in]  data                 Command response data struct
  * @param[in]  content_disposition  Content disposition
  */
 void
-cmd_response_data_set_content_disposition (cmd_response_data_t *data,
+cmd_response_data_set_content_disposition (gsad_command_response_data_t *data,
                                            gchar *content_disposition)
 {
   data->content_disposition = content_disposition;
 }
 
 /**
- * @brief Get content disposition of cmd_response_data_t struct
+ * @brief Get content disposition of gsad_command_response_data_t struct
  *
  * @param[in]  data  Command response data struct
  *
  * @return  Size of the response
  */
 const gchar *
-cmd_response_data_get_content_disposition (cmd_response_data_t *data)
+cmd_response_data_get_content_disposition (gsad_command_response_data_t *data)
 {
   return data->content_disposition;
 }
@@ -223,7 +225,7 @@ cmd_response_data_get_content_disposition (cmd_response_data_t *data)
  * @param[in]  content_type_string   Content type as string
  */
 void
-cmd_response_data_set_content_type_string (cmd_response_data_t *data,
+cmd_response_data_set_content_type_string (gsad_command_response_data_t *data,
                                            gchar *content_type_string)
 {
   data->content_type = GSAD_CONTENT_TYPE_STRING;
@@ -237,7 +239,7 @@ cmd_response_data_set_content_type_string (cmd_response_data_t *data,
  * @return Content type string if set
  */
 const gchar *
-cmd_response_data_get_content_type_string (cmd_response_data_t *data)
+cmd_response_data_get_content_type_string (gsad_command_response_data_t *data)
 {
   return data->content_type_string;
 }

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -162,8 +162,8 @@ gsad_command_response_data_get_status_code (gsad_command_response_data_t *data)
  * @param[in]  content_length  Content length of the response
  */
 void
-cmd_response_data_set_content_length (gsad_command_response_data_t *data,
-                                      gsize content_length)
+gsad_command_response_data_set_content_length (
+  gsad_command_response_data_t *data, gsize content_length)
 {
   data->content_length = content_length;
 }
@@ -176,7 +176,8 @@ cmd_response_data_set_content_length (gsad_command_response_data_t *data,
  * @return Content length of the response
  */
 gsize
-cmd_response_data_get_content_length (gsad_command_response_data_t *data)
+gsad_command_response_data_get_content_length (
+  gsad_command_response_data_t *data)
 {
   return data->content_length;
 }

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -189,8 +189,8 @@ gsad_command_response_data_get_content_length (
  * @param[in]  content_disposition  Content disposition
  */
 void
-cmd_response_data_set_content_disposition (gsad_command_response_data_t *data,
-                                           gchar *content_disposition)
+gsad_command_response_data_set_content_disposition (
+  gsad_command_response_data_t *data, gchar *content_disposition)
 {
   data->content_disposition = content_disposition;
 }
@@ -203,7 +203,8 @@ cmd_response_data_set_content_disposition (gsad_command_response_data_t *data,
  * @return  Size of the response
  */
 const gchar *
-cmd_response_data_get_content_disposition (gsad_command_response_data_t *data)
+gsad_command_response_data_get_content_disposition (
+  gsad_command_response_data_t *data)
 {
   return data->content_disposition;
 }

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -136,8 +136,8 @@ gsad_command_response_data_get_content_type (gsad_command_response_data_t *data)
  * @param[in]  http_status_code  HTTP status code
  */
 void
-cmd_response_data_set_status_code (gsad_command_response_data_t *data,
-                                   int http_status_code)
+gsad_command_response_data_set_status_code (gsad_command_response_data_t *data,
+                                            int http_status_code)
 {
   data->http_status_code = http_status_code;
 }
@@ -150,7 +150,7 @@ cmd_response_data_set_status_code (gsad_command_response_data_t *data,
  * @return  HTTP status code
  */
 int
-cmd_response_data_get_status_code (gsad_command_response_data_t *data)
+gsad_command_response_data_get_status_code (gsad_command_response_data_t *data)
 {
   return data->http_status_code;
 }

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -84,8 +84,8 @@ gsad_command_response_data_free (gsad_command_response_data_t *data)
  * @param[in]  allow_caching  allow_caching flag to set
  */
 void
-cmd_response_data_set_allow_caching (gsad_command_response_data_t *data,
-                                     gboolean allow_caching)
+gsad_command_response_data_set_allow_caching (
+  gsad_command_response_data_t *data, gboolean allow_caching)
 {
   data->allow_caching = (allow_caching != FALSE);
 }
@@ -98,7 +98,7 @@ cmd_response_data_set_allow_caching (gsad_command_response_data_t *data,
  * @return The allow_caching flag
  */
 gboolean
-cmd_response_data_is_allow_caching (gsad_command_response_data_t *data)
+gsad_command_response_data_is_allow_caching (gsad_command_response_data_t *data)
 {
   return data->allow_caching;
 }

--- a/src/gsad_cmd.c
+++ b/src/gsad_cmd.c
@@ -15,7 +15,7 @@
 /**
  * @brief Response information for commands.
  */
-struct cmd_response_data
+struct gsad_command_response_data
 {
   gboolean allow_caching;      ///> Whether the response may be cached.
   int http_status_code;        ///> HTTP status code.

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -55,11 +55,12 @@ gsad_command_response_data_get_content_length (
   gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_disposition (gsad_command_response_data_t *data,
-                                           gchar *content_disposition);
+gsad_command_response_data_set_content_disposition (
+  gsad_command_response_data_t *data, gchar *content_disposition);
 
 const gchar *
-cmd_response_data_get_content_disposition (gsad_command_response_data_t *data);
+gsad_command_response_data_get_content_disposition (
+  gsad_command_response_data_t *data);
 
 void
 gsad_command_response_data_set_content_type_string (

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -40,11 +40,11 @@ gsad_command_response_data_get_content_type (
   gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_status_code (gsad_command_response_data_t *data,
-                                   int http_status_code);
+gsad_command_response_data_set_status_code (gsad_command_response_data_t *data,
+                                            int http_status_code);
 
 int
-cmd_response_data_get_status_code (gsad_command_response_data_t *data);
+gsad_command_response_data_get_status_code (gsad_command_response_data_t *data);
 
 void
 cmd_response_data_set_content_length (gsad_command_response_data_t *data,

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -32,11 +32,12 @@ gsad_command_response_data_is_allow_caching (
   gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_type (gsad_command_response_data_t *data,
-                                    content_type_t content_type);
+gsad_command_response_data_set_content_type (gsad_command_response_data_t *data,
+                                             content_type_t content_type);
 
 content_type_t
-cmd_response_data_get_content_type (gsad_command_response_data_t *data);
+gsad_command_response_data_get_content_type (
+  gsad_command_response_data_t *data);
 
 void
 cmd_response_data_set_status_code (gsad_command_response_data_t *data,
@@ -60,9 +61,10 @@ const gchar *
 cmd_response_data_get_content_disposition (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_type_string (gsad_command_response_data_t *data,
-                                           gchar *content_type_string);
+gsad_command_response_data_set_content_type_string (
+  gsad_command_response_data_t *data, gchar *content_type_string);
 
 const gchar *
-cmd_response_data_get_content_type_string (gsad_command_response_data_t *data);
+gsad_command_response_data_get_content_type_string (
+  gsad_command_response_data_t *data);
 #endif /* not _GSAD_CMD_H */

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -15,53 +15,53 @@
 
 #include <glib.h>
 
-typedef struct gsad_command_response_data cmd_response_data_t;
+typedef struct gsad_command_response_data gsad_command_response_data_t;
 
-cmd_response_data_t *
+gsad_command_response_data_t *
 cmd_response_data_new ();
 
 void
-cmd_response_data_free (cmd_response_data_t *data);
+cmd_response_data_free (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_allow_caching (cmd_response_data_t *data,
+cmd_response_data_set_allow_caching (gsad_command_response_data_t *data,
                                      gboolean allow_caching);
 
 gboolean
-cmd_response_data_is_allow_caching (cmd_response_data_t *data);
+cmd_response_data_is_allow_caching (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_type (cmd_response_data_t *data,
+cmd_response_data_set_content_type (gsad_command_response_data_t *data,
                                     content_type_t content_type);
 
 content_type_t
-cmd_response_data_get_content_type (cmd_response_data_t *data);
+cmd_response_data_get_content_type (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_status_code (cmd_response_data_t *data,
+cmd_response_data_set_status_code (gsad_command_response_data_t *data,
                                    int http_status_code);
 
 int
-cmd_response_data_get_status_code (cmd_response_data_t *data);
+cmd_response_data_get_status_code (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_length (cmd_response_data_t *data,
+cmd_response_data_set_content_length (gsad_command_response_data_t *data,
                                       gsize content_length);
 
 gsize
-cmd_response_data_get_content_length (cmd_response_data_t *data);
+cmd_response_data_get_content_length (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_disposition (cmd_response_data_t *data,
+cmd_response_data_set_content_disposition (gsad_command_response_data_t *data,
                                            gchar *content_disposition);
 
 const gchar *
-cmd_response_data_get_content_disposition (cmd_response_data_t *data);
+cmd_response_data_get_content_disposition (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_type_string (cmd_response_data_t *data,
+cmd_response_data_set_content_type_string (gsad_command_response_data_t *data,
                                            gchar *content_type_string);
 
 const gchar *
-cmd_response_data_get_content_type_string (cmd_response_data_t *data);
+cmd_response_data_get_content_type_string (gsad_command_response_data_t *data);
 #endif /* not _GSAD_CMD_H */

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -18,10 +18,10 @@
 typedef struct gsad_command_response_data gsad_command_response_data_t;
 
 gsad_command_response_data_t *
-cmd_response_data_new ();
+gsad_command_response_data_new ();
 
 void
-cmd_response_data_free (gsad_command_response_data_t *data);
+gsad_command_response_data_free (gsad_command_response_data_t *data);
 
 void
 cmd_response_data_set_allow_caching (gsad_command_response_data_t *data,

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -47,11 +47,12 @@ int
 gsad_command_response_data_get_status_code (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_content_length (gsad_command_response_data_t *data,
-                                      gsize content_length);
+gsad_command_response_data_set_content_length (
+  gsad_command_response_data_t *data, gsize content_length);
 
 gsize
-cmd_response_data_get_content_length (gsad_command_response_data_t *data);
+gsad_command_response_data_get_content_length (
+  gsad_command_response_data_t *data);
 
 void
 cmd_response_data_set_content_disposition (gsad_command_response_data_t *data,

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -24,11 +24,12 @@ void
 gsad_command_response_data_free (gsad_command_response_data_t *data);
 
 void
-cmd_response_data_set_allow_caching (gsad_command_response_data_t *data,
-                                     gboolean allow_caching);
+gsad_command_response_data_set_allow_caching (
+  gsad_command_response_data_t *data, gboolean allow_caching);
 
 gboolean
-cmd_response_data_is_allow_caching (gsad_command_response_data_t *data);
+gsad_command_response_data_is_allow_caching (
+  gsad_command_response_data_t *data);
 
 void
 cmd_response_data_set_content_type (gsad_command_response_data_t *data,

--- a/src/gsad_cmd.h
+++ b/src/gsad_cmd.h
@@ -15,7 +15,7 @@
 
 #include <glib.h>
 
-typedef struct cmd_response_data cmd_response_data_t;
+typedef struct gsad_command_response_data cmd_response_data_t;
 
 cmd_response_data_t *
 cmd_response_data_new ();

--- a/src/gsad_command_response_data.c
+++ b/src/gsad_command_response_data.c
@@ -4,11 +4,11 @@
  */
 
 /**
- * @file gsad_cmd.c
+ * @file gsad_command_response_data.c
  * @brief Response data handling
  */
 
-#include "gsad_cmd.h"
+#include "gsad_command_response_data.h"
 
 #include <microhttpd.h> /* for MHD_HTTP_OK */
 

--- a/src/gsad_command_response_data.h
+++ b/src/gsad_command_response_data.h
@@ -8,8 +8,8 @@
  * @brief Headers for Response Data struct
  */
 
-#ifndef _GSAD_CMD_H
-#define _GSAD_CMD_H
+#ifndef _GSAD_COMMAND_RESPONSE_DATA_H
+#define _GSAD_COMMAND_RESPONSE_DATA_H
 
 #include "gsad_content_type.h" /* for content_type_t */
 
@@ -69,4 +69,5 @@ gsad_command_response_data_set_content_type_string (
 const gchar *
 gsad_command_response_data_get_content_type_string (
   gsad_command_response_data_t *data);
-#endif /* not _GSAD_CMD_H */
+
+#endif /* _GSAD_COMMAND_RESPONSE_DATA_H */

--- a/src/gsad_command_response_data_tests.c
+++ b/src/gsad_command_response_data_tests.c
@@ -1,0 +1,167 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "gsad_command_response_data.h"
+
+#include <cgreen/cgreen.h>
+#include <microhttpd.h> /* for MHD_HTTP_OK */
+
+Describe (gsad_command_response_data);
+BeforeEach (gsad_command_response_data)
+{
+}
+AfterEach (gsad_command_response_data)
+{
+}
+
+Ensure (gsad_command_response_data, should_allow_to_create_new)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+  assert_that (data, is_not_null);
+  assert_that (gsad_command_response_data_is_allow_caching (data), is_false);
+  assert_that (gsad_command_response_data_get_content_type (data),
+               is_equal_to (GSAD_CONTENT_TYPE_TEXT_HTML));
+  assert_that (gsad_command_response_data_get_content_type_string (data),
+               is_null);
+  assert_that (gsad_command_response_data_get_content_disposition (data),
+               is_null);
+  assert_that (gsad_command_response_data_get_status_code (data),
+               is_equal_to (MHD_HTTP_OK));
+  assert_that (gsad_command_response_data_get_content_length (data),
+               is_equal_to (0));
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data, should_allow_to_set_and_get_allow_caching)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+
+  assert_that (gsad_command_response_data_is_allow_caching (data), is_false);
+
+  gsad_command_response_data_set_allow_caching (data, TRUE);
+  assert_that (gsad_command_response_data_is_allow_caching (data), is_true);
+
+  gsad_command_response_data_set_allow_caching (data, FALSE);
+  assert_that (gsad_command_response_data_is_allow_caching (data), is_false);
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data, should_allow_to_set_and_get_content_type)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+
+  assert_that (gsad_command_response_data_get_content_type (data),
+               is_equal_to (GSAD_CONTENT_TYPE_TEXT_HTML));
+
+  gsad_command_response_data_set_content_type (data,
+                                               GSAD_CONTENT_TYPE_APP_JSON);
+  assert_that (gsad_command_response_data_get_content_type (data),
+               is_equal_to (GSAD_CONTENT_TYPE_APP_JSON));
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data, should_allow_to_set_and_get_status_code)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+
+  assert_that (gsad_command_response_data_get_status_code (data),
+               is_equal_to (MHD_HTTP_OK));
+
+  gsad_command_response_data_set_status_code (data, MHD_HTTP_NOT_FOUND);
+  assert_that (gsad_command_response_data_get_status_code (data),
+               is_equal_to (MHD_HTTP_NOT_FOUND));
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data, should_allow_to_set_and_get_content_length)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+
+  gsize content_length = gsad_command_response_data_get_content_length (data);
+  assert_that (content_length, is_equal_to (0));
+
+  gsad_command_response_data_set_content_length (data, 12345);
+  content_length = gsad_command_response_data_get_content_length (data);
+  assert_that (content_length, is_equal_to (12345));
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data,
+        should_allow_to_set_and_get_content_disposition)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+
+  assert_that (gsad_command_response_data_get_content_disposition (data),
+               is_null);
+
+  const gchar *content_disposition = "attachment; filename=\"example.txt\"";
+  gsad_command_response_data_set_content_disposition (
+    data, g_strdup (content_disposition));
+  assert_that (gsad_command_response_data_get_content_disposition (data),
+               is_equal_to_string (content_disposition));
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data,
+        should_allow_to_set_and_get_content_type_string)
+{
+  gsad_command_response_data_t *data = gsad_command_response_data_new ();
+
+  assert_that (gsad_command_response_data_get_content_type_string (data),
+               is_null);
+
+  const gchar *content_type_string = "application/vnd.api+json";
+  gsad_command_response_data_set_content_type_string (
+    data, g_strdup (content_type_string));
+  assert_that (gsad_command_response_data_get_content_type_string (data),
+               is_equal_to_string (content_type_string));
+
+  gsad_command_response_data_free (data);
+}
+
+Ensure (gsad_command_response_data, should_allow_to_free_null_data)
+{
+  gsad_command_response_data_free (NULL);
+}
+
+int
+main (int argc, char **argv)
+{
+  int ret;
+
+  TestSuite *suite = create_test_suite ();
+
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_create_new);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_set_and_get_allow_caching);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_set_and_get_status_code);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_set_and_get_content_type);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_set_and_get_content_length);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_set_and_get_content_disposition);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_set_and_get_content_type_string);
+  add_test_with_context (suite, gsad_command_response_data,
+                         should_allow_to_free_null_data);
+
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
+  destroy_test_suite (suite);
+
+  return ret;
+}

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -142,103 +142,103 @@
 
 static int
 gmp (gvm_connection_t *, gsad_credentials_t *, gchar **, entity_t *,
-     cmd_response_data_t *, const char *);
+     gsad_command_response_data_t *, const char *);
 
 static int
 gmpf (gvm_connection_t *, gsad_credentials_t *, gchar **, entity_t *,
-      cmd_response_data_t *, const char *, ...);
+      gsad_command_response_data_t *, const char *, ...);
 
 static char *
 get_alert (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-           cmd_response_data_t *);
+           gsad_command_response_data_t *);
 
 static char *
 get_asset (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-           cmd_response_data_t *);
+           gsad_command_response_data_t *);
 
 static char *
 get_config_family (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 static char *
 get_filter (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-            cmd_response_data_t *);
+            gsad_command_response_data_t *);
 
 static char *
 get_group (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-           cmd_response_data_t *);
+           gsad_command_response_data_t *);
 
 static char *
 get_credential (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                const char *, cmd_response_data_t *);
+                const char *, gsad_command_response_data_t *);
 
 static char *
 get_note (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-          cmd_response_data_t *);
+          gsad_command_response_data_t *);
 
 static char *
 get_override (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              const char *, cmd_response_data_t *);
+              const char *, gsad_command_response_data_t *);
 
 static char *
 get_permission (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                const char *, cmd_response_data_t *);
+                const char *, gsad_command_response_data_t *);
 
 static char *
 get_port_list (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               const char *, cmd_response_data_t *);
+               const char *, gsad_command_response_data_t *);
 
 static char *
 get_tag (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-         cmd_response_data_t *);
+         gsad_command_response_data_t *);
 
 static char *
 get_target (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-            cmd_response_data_t *);
+            gsad_command_response_data_t *);
 
 static char *
 get_report_config (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   const char *, cmd_response_data_t *);
+                   const char *, gsad_command_response_data_t *);
 
 static char *
 get_report_format (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   const char *, cmd_response_data_t *);
+                   const char *, gsad_command_response_data_t *);
 
 static char *
 get_role (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-          cmd_response_data_t *);
+          gsad_command_response_data_t *);
 
 static char *
 get_scanner (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-             cmd_response_data_t *);
+             gsad_command_response_data_t *);
 
 static char *
 get_schedule (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              const char *, cmd_response_data_t *);
+              const char *, gsad_command_response_data_t *);
 
 static char *
 get_user (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-          cmd_response_data_t *);
+          gsad_command_response_data_t *);
 
 static char *
 wizard (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-        cmd_response_data_t *);
+        gsad_command_response_data_t *);
 
 static char *
 wizard_get (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-            cmd_response_data_t *);
+            gsad_command_response_data_t *);
 
 static int
 gmp_success (entity_t entity);
 
 static gchar *
 response_from_entity (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      entity_t, const char *, cmd_response_data_t *);
+                      entity_t, const char *, gsad_command_response_data_t *);
 
 static gchar *
 action_result (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *, const char *action, const char *message,
-               const char *details, const char *id);
+               gsad_command_response_data_t *, const char *action,
+               const char *message, const char *details, const char *id);
 /* Helpers. */
 
 /**
@@ -278,7 +278,8 @@ typedef struct
  */
 static char *
 envelope_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, gchar *xml, cmd_response_data_t *response_data)
+              params_t *params, gchar *xml,
+              gsad_command_response_data_t *response_data)
 {
   return gsad_http_create_envelope (credentials, xml, response_data);
 }
@@ -383,7 +384,7 @@ static char *
 check_modify_config (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
                      const char *next, const char *fail_next, int *success,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   gchar *response;
@@ -476,7 +477,7 @@ gmp_success (entity_t entity)
  */
 void
 set_http_status_from_entity (entity_t entity,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   if (entity == NULL)
     cmd_response_data_set_status_code (response_data,
@@ -508,7 +509,7 @@ set_http_status_from_entity (entity_t entity,
 static int
 gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
      gchar **response, entity_t *entity_return,
-     cmd_response_data_t *response_data, const char *command)
+     gsad_command_response_data_t *response_data, const char *command)
 {
   int ret;
   entity_t entity;
@@ -550,7 +551,7 @@ gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static int
 gmpf (gvm_connection_t *connection, gsad_credentials_t *credentials,
       gchar **response, entity_t *entity_return,
-      cmd_response_data_t *response_data, const char *format, ...)
+      gsad_command_response_data_t *response_data, const char *format, ...)
 {
   int ret;
   gchar *command;
@@ -578,7 +579,7 @@ gmpf (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 static int
 setting_get_value (gvm_connection_t *connection, const char *setting_id,
-                   gchar **value, cmd_response_data_t *response_data)
+                   gchar **value, gsad_command_response_data_t *response_data)
 {
   int ret;
   entity_t entity;
@@ -649,7 +650,7 @@ setting_get_value (gvm_connection_t *connection, const char *setting_id,
  */
 static gchar *
 action_result (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data,
+               params_t *params, gsad_command_response_data_t *response_data,
                const char *action, const char *message, const char *details,
                const char *id)
 {
@@ -688,7 +689,7 @@ action_result (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 gchar *
 message_invalid (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data,
+                 params_t *params, gsad_command_response_data_t *response_data,
                  const char *message, const char *op_name)
 {
   gchar *ret = action_result (connection, credentials, params, response_data,
@@ -716,7 +717,7 @@ static gchar *
 response_from_entity (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
                       entity_t entity, const char *action,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   gchar *res;
   entity_t status_details_entity;
@@ -752,7 +753,8 @@ response_from_entity (gvm_connection_t *connection,
 char *
 get_entity (gvm_connection_t *connection, const char *type,
             gsad_credentials_t *credentials, params_t *params,
-            gmp_arguments_t *arguments, cmd_response_data_t *response_data)
+            gmp_arguments_t *arguments,
+            gsad_command_response_data_t *response_data)
 {
   GString *xml;
   gchar *cmd;
@@ -845,7 +847,7 @@ char *
 get_one (gvm_connection_t *connection, const char *type,
          gsad_credentials_t *credentials, params_t *params,
          const char *extra_xml, gmp_arguments_t *arguments,
-         cmd_response_data_t *response_data)
+         gsad_command_response_data_t *response_data)
 {
   gchar *id_name;
   const gchar *id;
@@ -895,7 +897,8 @@ get_one (gvm_connection_t *connection, const char *type,
 static char *
 get_entities (gvm_connection_t *connection, const char *type,
               gsad_credentials_t *credentials, params_t *params,
-              gmp_arguments_t *arguments, cmd_response_data_t *response_data)
+              gmp_arguments_t *arguments,
+              gsad_command_response_data_t *response_data)
 {
   GString *xml;
   gchar *cmd;
@@ -978,7 +981,8 @@ get_entities (gvm_connection_t *connection, const char *type,
 static char *
 get_many (gvm_connection_t *connection, const char *type,
           gsad_credentials_t *credentials, params_t *params,
-          gmp_arguments_t *arguments, cmd_response_data_t *response_data)
+          gmp_arguments_t *arguments,
+          gsad_command_response_data_t *response_data)
 {
   const gchar *filter_id, *filter;
   const gchar *details;
@@ -1115,7 +1119,7 @@ format_file_name (gchar *fname_format, gsad_credentials_t *credentials,
 char *
 export_resource (gvm_connection_t *connection, const char *type,
                  gsad_credentials_t *credentials, params_t *params,
-                 cmd_response_data_t *response_data)
+                 gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity;
@@ -1268,7 +1272,7 @@ export_resource (gvm_connection_t *connection, const char *type,
 static char *
 export_many (gvm_connection_t *connection, const char *type,
              gsad_credentials_t *credentials, params_t *params,
-             cmd_response_data_t *response_data)
+             gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   char *content = NULL;
@@ -1445,7 +1449,7 @@ export_many (gvm_connection_t *connection, const char *type,
 char *
 delete_resource (gvm_connection_t *connection, const char *type,
                  gsad_credentials_t *credentials, params_t *params,
-                 gboolean ultimate, cmd_response_data_t *response_data)
+                 gboolean ultimate, gsad_command_response_data_t *response_data)
 {
   gchar *html, *id_name, *resource_id, *extra_attribs;
   entity_t entity;
@@ -1551,7 +1555,7 @@ delete_resource (gvm_connection_t *connection, const char *type,
 char *
 move_resource_to_trash (gvm_connection_t *connection, const char *type,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return delete_resource (connection, type, credentials, params, FALSE,
                           response_data);
@@ -1570,7 +1574,7 @@ move_resource_to_trash (gvm_connection_t *connection, const char *type,
 char *
 delete_from_trash_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   const gchar *resource_type;
 
@@ -1597,7 +1601,7 @@ delete_from_trash_gmp (gvm_connection_t *connection,
 char *
 resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
                  params_t *params, const char *type, const char *action,
-                 cmd_response_data_t *response_data)
+                 gsad_command_response_data_t *response_data)
 {
   gchar *html, *param_name;
   const char *resource_id;
@@ -1741,7 +1745,7 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 create_report_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   int ret;
@@ -1831,7 +1835,7 @@ create_report_gmp (gvm_connection_t *connection,
 char *
 create_import_task_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   int ret;
@@ -1909,7 +1913,7 @@ create_import_task_gmp (gvm_connection_t *connection,
  */
 char *
 create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   int ret;
@@ -2220,7 +2224,7 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 create_agent_group_task_gmp (gvm_connection_t *connection,
                              gsad_credentials_t *credentials, params_t *params,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   int ret;
@@ -2472,7 +2476,7 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
 char *
 create_oci_image_task_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   int ret;
@@ -2721,7 +2725,7 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
  */
 char *
 delete_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "task", credentials, params,
                                  response_data);
@@ -2739,7 +2743,7 @@ delete_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html, *format;
   const char *comment, *name, *schedule_id, *in_assets;
@@ -2968,7 +2972,7 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 save_import_task_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   gchar *format, *html;
   const char *comment, *name, *task_id;
@@ -3060,7 +3064,7 @@ save_import_task_gmp (gvm_connection_t *connection,
 char *
 save_agent_group_task_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   gchar *html = NULL, *format = NULL;
   const char *comment, *name, *schedule_id, *schedule_periods;
@@ -3188,7 +3192,7 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
 char *
 save_oci_image_task_gmp (gvm_connection_t *connection,
                          gsad_credentials_t *credentials, params_t *params,
-                         cmd_response_data_t *response_data)
+                         gsad_command_response_data_t *response_data)
 {
   gchar *html = NULL, *format = NULL;
   const char *comment, *name, *schedule_id, *schedule_periods;
@@ -3340,7 +3344,7 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
  */
 char *
 export_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "task", credentials, params,
                           response_data);
@@ -3359,7 +3363,7 @@ export_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_tasks_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "task", credentials, params, response_data);
 }
@@ -3376,7 +3380,7 @@ export_tasks_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 stop_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return resource_action (connection, credentials, params, "task", "stop",
                           response_data);
@@ -3394,7 +3398,7 @@ stop_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 resume_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return resource_action (connection, credentials, params, "task", "resume",
                           response_data);
@@ -3412,7 +3416,7 @@ resume_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 start_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return resource_action (connection, credentials, params, "task", "start",
                           response_data);
@@ -3430,7 +3434,7 @@ start_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *command, *html;
   const char *task_id, *slave_id;
@@ -3498,7 +3502,7 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_info_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   const gchar *info_type;
   const gchar *info_name;
@@ -3550,7 +3554,7 @@ get_info_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_tasks_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *schedules_only, *ignore_pagination, *usage_type;
   gmp_arguments_t *arguments;
@@ -3594,7 +3598,7 @@ get_tasks_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "task", credentials, params, NULL, NULL,
                   response_data);
@@ -3613,7 +3617,7 @@ get_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 create_credential_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -4096,7 +4100,7 @@ create_credential_gmp (gvm_connection_t *connection,
 static char *
 get_credential (gvm_connection_t *connection, gsad_credentials_t *credentials,
                 params_t *params, const char *extra_xml,
-                cmd_response_data_t *response_data)
+                gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments = gmp_arguments_new ();
   gmp_arguments_add (arguments, "targets", "1");
@@ -4119,7 +4123,7 @@ get_credential (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_credential_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return get_credential (connection, credentials, params, NULL, response_data);
 }
@@ -4137,7 +4141,7 @@ get_credential_gmp (gvm_connection_t *connection,
 char *
 download_credential_gmp (gvm_connection_t *connection,
                          gsad_credentials_t *credentials, params_t *params,
-                         cmd_response_data_t *response_data)
+                         gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL, credential_entity = NULL;
   const gchar *credential_id, *format;
@@ -4316,7 +4320,7 @@ download_credential_gmp (gvm_connection_t *connection,
 char *
 export_credential_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "credential", credentials, params,
                           response_data);
@@ -4336,7 +4340,7 @@ export_credential_gmp (gvm_connection_t *connection,
 char *
 export_credentials_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "credential", credentials, params,
                       response_data);
@@ -4355,7 +4359,7 @@ export_credentials_gmp (gvm_connection_t *connection,
 char *
 get_credentials_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "credentials", credentials, params, NULL,
                    response_data);
@@ -4374,7 +4378,7 @@ get_credentials_gmp (gvm_connection_t *connection,
 char *
 get_credential_stores_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   const char *credential_store_uuid =
     params_value (params, "credential_store_id");
@@ -4444,7 +4448,7 @@ add_preference_to_xml_base64 (GString *xml, const char *name,
 char *
 modify_credential_store_gmp (gvm_connection_t *connection,
                              gsad_credentials_t *credentials, params_t *params,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   gchar *xml, *format;
   int ret;
@@ -4608,7 +4612,7 @@ modify_credential_store_gmp (gvm_connection_t *connection,
 char *
 verify_credential_store_gmp (gvm_connection_t *connection,
                              gsad_credentials_t *credentials, params_t *params,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *credential_store_id;
@@ -4674,7 +4678,7 @@ verify_credential_store_gmp (gvm_connection_t *connection,
 char *
 delete_credential_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "credential", credentials, params,
                                  response_data);
@@ -4693,7 +4697,7 @@ delete_credential_gmp (gvm_connection_t *connection,
 char *
 save_credential_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html = NULL;
@@ -5043,7 +5047,7 @@ save_credential_gmp (gvm_connection_t *connection,
 char *
 get_aggregate_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   params_t *data_columns, *text_columns;
   params_t *sort_fields, *sort_stats, *sort_orders;
@@ -5252,7 +5256,7 @@ get_aggregate_gmp (gvm_connection_t *connection,
 static char *
 new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
            params_t *params, const char *extra_xml,
-           cmd_response_data_t *response_data)
+           gsad_command_response_data_t *response_data)
 {
   GString *xml;
   int ret;
@@ -5498,14 +5502,14 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 new_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return new_alert (connection, credentials, params, NULL, response_data);
 }
 
 char *
 get_alerts (gvm_connection_t *connection, gsad_credentials_t *, params_t *,
-            const char *, cmd_response_data_t *);
+            const char *, gsad_command_response_data_t *);
 
 #define EVENT_TYPE_NEW_SECINFO "New SecInfo arrived"
 #define EVENT_TYPE_UPDATED_SECINFO "Updated SecInfo arrived"
@@ -5780,7 +5784,7 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
  */
 char *
 create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -5913,7 +5917,7 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 delete_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "alert", credentials, params,
                                  response_data);
@@ -5933,7 +5937,7 @@ delete_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
            params_t *params, const char *extra_xml,
-           cmd_response_data_t *response_data)
+           gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -5956,7 +5960,7 @@ get_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_alert (connection, credentials, params, NULL, response_data);
 }
@@ -5973,7 +5977,7 @@ get_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_alerts_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "alerts", credentials, params, NULL,
                    response_data);
@@ -5993,7 +5997,7 @@ get_alerts_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
             params_t *params, const char *extra_xml,
-            cmd_response_data_t *response_data)
+            gsad_command_response_data_t *response_data)
 {
   GString *xml;
   gchar *edit;
@@ -6253,7 +6257,7 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 edit_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return edit_alert (connection, credentials, params, NULL, response_data);
 }
@@ -6270,7 +6274,7 @@ edit_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   GString *xml;
   int ret;
@@ -6410,7 +6414,7 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *alert_id;
@@ -6475,7 +6479,7 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "alert", credentials, params,
                           response_data);
@@ -6495,7 +6499,7 @@ export_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_alerts_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "alert", credentials, params, response_data);
 }
@@ -6513,7 +6517,7 @@ export_alerts_gmp (gvm_connection_t *connection,
 char *
 create_target_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html, *command;
@@ -6777,7 +6781,7 @@ create_target_gmp (gvm_connection_t *connection,
  */
 char *
 clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-           params_t *params, cmd_response_data_t *response_data)
+           params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *id, *type, *alterable;
@@ -6864,7 +6868,7 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 delete_target_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "target", credentials, params,
                                  response_data);
@@ -6882,7 +6886,7 @@ delete_target_gmp (gvm_connection_t *connection,
  */
 char *
 restore_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-             params_t *params, cmd_response_data_t *response_data)
+             params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *ret;
   entity_t entity;
@@ -6943,7 +6947,7 @@ restore_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 empty_trashcan_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   gchar *ret;
   entity_t entity;
@@ -6992,7 +6996,7 @@ empty_trashcan_gmp (gvm_connection_t *connection,
  */
 char *
 create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   char *ret;
   gchar *response;
@@ -7106,7 +7110,7 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 delete_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "tag", credentials, params,
                                  response_data);
@@ -7124,7 +7128,7 @@ delete_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *response;
   const char *name, *comment, *filter, *value, *resource_type, *active;
@@ -7251,7 +7255,7 @@ save_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "tag", credentials, params,
                           response_data);
@@ -7270,7 +7274,7 @@ export_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_tags_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "tag", credentials, params, response_data);
 }
@@ -7289,7 +7293,7 @@ export_tags_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_tag (gvm_connection_t *connection, gsad_credentials_t *credentials,
          params_t *params, const char *extra_xml,
-         cmd_response_data_t *response_data)
+         gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "tag", credentials, params, extra_xml, NULL,
                   response_data);
@@ -7307,7 +7311,7 @@ get_tag (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-             params_t *params, cmd_response_data_t *response_data)
+             params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_tag (connection, credentials, params, NULL, response_data);
 }
@@ -7324,7 +7328,7 @@ get_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_tags_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "tags", credentials, params, NULL,
                    response_data);
@@ -7342,7 +7346,7 @@ get_tags_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 toggle_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *tag_id, *enable;
@@ -7411,7 +7415,7 @@ toggle_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_target (gvm_connection_t *connection, gsad_credentials_t *credentials,
             params_t *params, const char *extra_xml,
-            cmd_response_data_t *response_data)
+            gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -7434,7 +7438,7 @@ get_target (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_target (connection, credentials, params, NULL, response_data);
 }
@@ -7451,7 +7455,7 @@ get_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_targets_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "targets", credentials, params, NULL,
                    response_data);
@@ -7469,7 +7473,7 @@ get_targets_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *name, *comment, *target_id;
@@ -7733,7 +7737,7 @@ save_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_target_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "target", credentials, params,
                           response_data);
@@ -7753,7 +7757,7 @@ export_target_gmp (gvm_connection_t *connection,
 char *
 export_targets_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "target", credentials, params, response_data);
 }
@@ -7771,7 +7775,7 @@ export_targets_gmp (gvm_connection_t *connection,
 char *
 create_config_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   gchar *html, *response;
   const char *name, *comment, *base, *usage_type, *scanner = NULL;
@@ -7857,7 +7861,7 @@ create_config_gmp (gvm_connection_t *connection,
 char *
 import_config_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   gchar *command, *html;
   entity_t entity;
@@ -7925,7 +7929,7 @@ import_config_gmp (gvm_connection_t *connection,
  */
 char *
 get_configs_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *usage_type;
   gmp_arguments_t *arguments = NULL;
@@ -7956,7 +7960,7 @@ get_configs_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
 
@@ -7982,7 +7986,7 @@ get_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   int gmp_ret;
   char *ret;
@@ -8216,7 +8220,7 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_config_family (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   GString *xml;
   const char *config_id, *family, *sort_field, *sort_order;
@@ -8294,7 +8298,7 @@ get_config_family (gvm_connection_t *connection,
 char *
 get_config_family_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return get_config_family (connection, credentials, params, response_data);
 }
@@ -8312,7 +8316,7 @@ get_config_family_gmp (gvm_connection_t *connection,
 char *
 edit_config_family_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return get_config_family (connection, credentials, params, response_data);
 }
@@ -8330,7 +8334,7 @@ edit_config_family_gmp (gvm_connection_t *connection,
 char *
 edit_config_family_all_gmp (gvm_connection_t *connection,
                             gsad_credentials_t *credentials, params_t *params,
-                            cmd_response_data_t *response_data)
+                            gsad_command_response_data_t *response_data)
 {
   GString *xml;
   const char *config_id, *family, *sort_field, *sort_order;
@@ -8414,7 +8418,7 @@ edit_config_family_all_gmp (gvm_connection_t *connection,
 char *
 save_config_family_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   char *ret;
   const char *config_id, *family;
@@ -8501,7 +8505,7 @@ save_config_family_gmp (gvm_connection_t *connection,
 char *
 get_config_nvt_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   GString *xml;
   const char *config_id, *sort_field, *sort_order, *nvt;
@@ -8574,7 +8578,7 @@ get_config_nvt_gmp (gvm_connection_t *connection,
 char *
 get_nvt_families_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   return get_entities (connection, "nvt_families", credentials, params, NULL,
                        response_data);
@@ -8593,7 +8597,7 @@ get_nvt_families_gmp (gvm_connection_t *connection,
 char *
 save_config_nvt_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   params_t *preferences;
   const char *config_id;
@@ -8812,7 +8816,7 @@ save_config_nvt_gmp (gvm_connection_t *connection,
 char *
 delete_config_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "config", credentials, params,
                                  response_data);
@@ -8831,7 +8835,7 @@ delete_config_gmp (gvm_connection_t *connection,
 char *
 export_config_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "config", credentials, params,
                           response_data);
@@ -8851,7 +8855,7 @@ export_config_gmp (gvm_connection_t *connection,
 char *
 export_configs_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "config", credentials, params, response_data);
 }
@@ -8868,7 +8872,7 @@ export_configs_gmp (gvm_connection_t *connection,
  */
 char *
 export_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "note", credentials, params,
                           response_data);
@@ -8887,7 +8891,7 @@ export_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_notes_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "note", credentials, params, response_data);
 }
@@ -8905,7 +8909,7 @@ export_notes_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_override_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "override", credentials, params,
                           response_data);
@@ -8925,7 +8929,7 @@ export_override_gmp (gvm_connection_t *connection,
 char *
 export_overrides_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "override", credentials, params,
                       response_data);
@@ -8945,7 +8949,7 @@ export_overrides_gmp (gvm_connection_t *connection,
 char *
 export_port_list_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "port_list", credentials, params,
                           response_data);
@@ -8965,7 +8969,7 @@ export_port_list_gmp (gvm_connection_t *connection,
 char *
 export_port_lists_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "port_list", credentials, params,
                       response_data);
@@ -8984,7 +8988,7 @@ export_port_lists_gmp (gvm_connection_t *connection,
 char *
 export_preference_file_gmp (gvm_connection_t *connection,
                             gsad_credentials_t *credentials, params_t *params,
-                            cmd_response_data_t *response_data)
+                            gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity, preference_entity, value_entity;
@@ -9081,7 +9085,7 @@ export_preference_file_gmp (gvm_connection_t *connection,
 char *
 export_report_config_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "report_config", credentials, params,
                           response_data);
@@ -9101,7 +9105,7 @@ export_report_config_gmp (gvm_connection_t *connection,
 char *
 export_report_configs_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "report_config", credentials, params,
                       response_data);
@@ -9121,7 +9125,7 @@ export_report_configs_gmp (gvm_connection_t *connection,
 char *
 export_report_format_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "report_format", credentials, params,
                           response_data);
@@ -9141,7 +9145,7 @@ export_report_format_gmp (gvm_connection_t *connection,
 char *
 export_report_formats_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "report_format", credentials, params,
                       response_data);
@@ -9160,7 +9164,7 @@ export_report_formats_gmp (gvm_connection_t *connection,
 char *
 delete_report_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return delete_resource (connection, "report", credentials, params, TRUE,
                           response_data);
@@ -9180,7 +9184,7 @@ delete_report_gmp (gvm_connection_t *connection,
 char *
 get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
             params_t *params, const char *extra_xml,
-            cmd_response_data_t *response_data)
+            gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity;
@@ -9578,7 +9582,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_report_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_report (connection, credentials, params, NULL, response_data);
 }
@@ -9596,7 +9600,7 @@ get_report_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_report_errors_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity;
@@ -9690,7 +9694,7 @@ get_report_errors_gmp (gvm_connection_t *connection,
 char *
 get_report_hosts_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity;
@@ -9786,7 +9790,7 @@ get_report_hosts_gmp (gvm_connection_t *connection,
 char *
 get_report_ports_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity;
@@ -9881,7 +9885,7 @@ char *
 get_report_tls_certificates_gmp (gvm_connection_t *connection,
                                  gsad_credentials_t *credentials,
                                  params_t *params,
-                                 cmd_response_data_t *response_data)
+                                 gsad_command_response_data_t *response_data)
 {
   GString *xml;
   entity_t entity;
@@ -9974,7 +9978,7 @@ get_report_tls_certificates_gmp (gvm_connection_t *connection,
  */
 char *
 report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   const char *alert_id, *report_id;
@@ -10079,7 +10083,7 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_reports_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const gchar *filter, *filter_id, *details, *usage_type;
   gmp_arguments_t *arguments;
@@ -10140,7 +10144,7 @@ get_reports_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 download_ssl_cert (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   const char *ssl_cert;
   gchar *cert;
@@ -10180,7 +10184,7 @@ download_ssl_cert (gvm_connection_t *connection,
  */
 char *
 download_ca_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *ca_pub;
   char *unescaped;
@@ -10212,7 +10216,7 @@ download_ca_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 download_key_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *key_pub;
   char *unescaped;
@@ -10247,7 +10251,7 @@ download_key_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_result_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "result", credentials, params,
                           response_data);
@@ -10267,7 +10271,7 @@ export_result_gmp (gvm_connection_t *connection,
 char *
 export_results_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "result", credentials, params, response_data);
 }
@@ -10284,7 +10288,7 @@ export_results_gmp (gvm_connection_t *connection,
  */
 char *
 get_results_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const gchar *_and_report_id;
   gmp_arguments_t *arguments = NULL;
@@ -10316,7 +10320,7 @@ get_results_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_result_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "result", credentials, params, NULL, NULL,
                   response_data);
@@ -10334,7 +10338,7 @@ get_result_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_notes_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "notes", credentials, params, NULL,
                    response_data);
@@ -10354,7 +10358,7 @@ get_notes_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_note (gvm_connection_t *connection, gsad_credentials_t *credentials,
           params_t *params, const char *extra_xml,
-          cmd_response_data_t *response_data)
+          gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -10377,7 +10381,7 @@ get_note (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_note (connection, credentials, params, NULL, response_data);
 }
@@ -10520,7 +10524,7 @@ get_result_id_from_params (params_t *params)
  */
 char *
 create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   char *ret;
   gchar *response;
@@ -10618,7 +10622,7 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 delete_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "note", credentials, params,
                                  response_data);
@@ -10636,7 +10640,7 @@ delete_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *response;
   entity_t entity;
@@ -10736,7 +10740,7 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_overrides_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "overrides", credentials, params, NULL,
                    response_data);
@@ -10756,7 +10760,7 @@ get_overrides_gmp (gvm_connection_t *connection,
 static char *
 get_override (gvm_connection_t *connection, gsad_credentials_t *credentials,
               params_t *params, const char *extra_xml,
-              cmd_response_data_t *response_data)
+              gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -10779,7 +10783,7 @@ get_override (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_override_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_override (connection, credentials, params, NULL, response_data);
 }
@@ -10797,7 +10801,7 @@ get_override_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 create_override_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   char *ret;
   gchar *response;
@@ -10921,7 +10925,7 @@ create_override_gmp (gvm_connection_t *connection,
 char *
 delete_override_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "override", credentials, params,
                                  response_data);
@@ -10940,7 +10944,7 @@ delete_override_gmp (gvm_connection_t *connection,
 char *
 save_override_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   gchar *response;
   entity_t entity;
@@ -11050,7 +11054,7 @@ save_override_gmp (gvm_connection_t *connection,
  */
 char *
 get_scanners_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "scanners", credentials, params, NULL,
                    response_data);
@@ -11070,7 +11074,7 @@ get_scanners_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_scanner (gvm_connection_t *connection, gsad_credentials_t *credentials,
              params_t *params, const char *extra_xml,
-             cmd_response_data_t *response_data)
+             gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "scanner", credentials, params, extra_xml, NULL,
                   response_data);
@@ -11088,7 +11092,7 @@ get_scanner (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_scanner (connection, credentials, params, NULL, response_data);
 }
@@ -11106,7 +11110,7 @@ get_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_scanner_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "scanner", credentials, params,
                           response_data);
@@ -11125,7 +11129,7 @@ export_scanner_gmp (gvm_connection_t *connection,
 char *
 export_scanners_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "scanner", credentials, params,
                       response_data);
@@ -11144,7 +11148,7 @@ export_scanners_gmp (gvm_connection_t *connection,
 char *
 verify_scanner_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *scanner_id;
@@ -11209,7 +11213,7 @@ verify_scanner_gmp (gvm_connection_t *connection,
 char *
 create_scanner_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   int ret;
   char *html;
@@ -11309,7 +11313,7 @@ create_scanner_gmp (gvm_connection_t *connection,
 char *
 delete_scanner_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "scanner", credentials, params,
                                  response_data);
@@ -11327,7 +11331,7 @@ delete_scanner_gmp (gvm_connection_t *connection,
  */
 char *
 save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   GString *xml = NULL;
   entity_t entity = NULL;
@@ -11438,7 +11442,7 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_schedule (gvm_connection_t *connection, gsad_credentials_t *credentials,
               params_t *params, const char *extra_xml,
-              cmd_response_data_t *response_data)
+              gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -11461,7 +11465,7 @@ get_schedule (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_schedule_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_schedule (connection, credentials, params, NULL, response_data);
 }
@@ -11479,7 +11483,7 @@ get_schedule_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_schedules_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "schedules", credentials, params, NULL,
                    response_data);
@@ -11498,7 +11502,7 @@ get_schedules_gmp (gvm_connection_t *connection,
 char *
 create_schedule_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   char *ret;
   gchar *response;
@@ -11579,7 +11583,7 @@ create_schedule_gmp (gvm_connection_t *connection,
 char *
 delete_schedule_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "schedule", credentials, params,
                                  response_data);
@@ -11598,7 +11602,7 @@ delete_schedule_gmp (gvm_connection_t *connection,
 char *
 get_system_reports_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   GString *xml;
   const char *slave_id;
@@ -11658,7 +11662,7 @@ get_system_reports_gmp (gvm_connection_t *connection,
 char *
 get_system_report_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -11753,7 +11757,7 @@ char *
 get_system_report_gmp_from_url (gvm_connection_t *connection,
                                 gsad_credentials_t *credentials,
                                 const char *url, params_t *params,
-                                cmd_response_data_t *response_data)
+                                gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   entity_t report_entity;
@@ -11879,7 +11883,8 @@ get_system_report_gmp_from_url (gvm_connection_t *connection,
 static char *
 get_report_config (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   const char *extra_xml, cmd_response_data_t *response_data)
+                   const char *extra_xml,
+                   gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "report_config", credentials, params, extra_xml,
                   NULL, response_data);
@@ -11898,7 +11903,7 @@ get_report_config (gvm_connection_t *connection,
 char *
 get_report_config_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return get_report_config (connection, credentials, params, NULL,
                             response_data);
@@ -11917,7 +11922,7 @@ get_report_config_gmp (gvm_connection_t *connection,
 char *
 get_report_configs_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "report_configs", credentials, params, NULL,
                    response_data);
@@ -12043,7 +12048,7 @@ buffer_report_config_params (GString *string, GHashTable *config_params,
 char *
 create_report_config_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -12134,7 +12139,7 @@ create_report_config_gmp (gvm_connection_t *connection,
 char *
 delete_report_config_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "report_config", credentials,
                                  params, response_data);
@@ -12153,7 +12158,7 @@ delete_report_config_gmp (gvm_connection_t *connection,
 char *
 save_report_config_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -12245,7 +12250,8 @@ save_report_config_gmp (gvm_connection_t *connection,
 static char *
 get_report_format (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   const char *extra_xml, cmd_response_data_t *response_data)
+                   const char *extra_xml,
+                   gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -12271,7 +12277,7 @@ get_report_format (gvm_connection_t *connection,
 char *
 get_report_format_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return get_report_format (connection, credentials, params, NULL,
                             response_data);
@@ -12290,7 +12296,7 @@ get_report_format_gmp (gvm_connection_t *connection,
 char *
 get_report_formats_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "report_formats", credentials, params, NULL,
                    response_data);
@@ -12309,7 +12315,7 @@ get_report_formats_gmp (gvm_connection_t *connection,
 char *
 delete_report_format_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "report_format", credentials,
                                  params, response_data);
@@ -12328,7 +12334,7 @@ delete_report_format_gmp (gvm_connection_t *connection,
 char *
 import_report_format_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   gchar *command, *html;
   entity_t entity;
@@ -12400,7 +12406,7 @@ import_report_format_gmp (gvm_connection_t *connection,
 char *
 save_report_format_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -12671,7 +12677,7 @@ save_report_format_gmp (gvm_connection_t *connection,
 char *
 get_resource_names_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   const gchar *type;
   gmp_arguments_t *arguments;
@@ -12700,7 +12706,7 @@ get_resource_names_gmp (gvm_connection_t *connection,
  */
 char *
 run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *name;
   int ret;
@@ -12836,7 +12842,7 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_trash_alerts_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -12864,7 +12870,7 @@ get_trash_alerts_gmp (gvm_connection_t *connection,
 char *
 get_trash_configs_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -12892,7 +12898,7 @@ get_trash_configs_gmp (gvm_connection_t *connection,
 char *
 get_trash_credentials_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -12920,7 +12926,7 @@ get_trash_credentials_gmp (gvm_connection_t *connection,
 char *
 get_trash_filters_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -12948,7 +12954,7 @@ get_trash_filters_gmp (gvm_connection_t *connection,
 char *
 get_trash_groups_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -12976,7 +12982,7 @@ get_trash_groups_gmp (gvm_connection_t *connection,
 char *
 get_trash_notes_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13005,7 +13011,7 @@ char *
 get_trash_oci_image_targets_gmp (gvm_connection_t *connection,
                                  gsad_credentials_t *credentials,
                                  params_t *params,
-                                 cmd_response_data_t *response_data)
+                                 gsad_command_response_data_t *response_data)
 {
   GString *xml = g_string_new ("<get_trash>");
 
@@ -13032,7 +13038,7 @@ get_trash_oci_image_targets_gmp (gvm_connection_t *connection,
 char *
 get_trash_overrides_gmp (gvm_connection_t *connection,
                          gsad_credentials_t *credentials, params_t *params,
-                         cmd_response_data_t *response_data)
+                         gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13060,7 +13066,7 @@ get_trash_overrides_gmp (gvm_connection_t *connection,
 char *
 get_trash_permissions_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13088,7 +13094,7 @@ get_trash_permissions_gmp (gvm_connection_t *connection,
 char *
 get_trash_port_lists_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13116,7 +13122,7 @@ get_trash_port_lists_gmp (gvm_connection_t *connection,
 char *
 get_trash_report_configs_gmp (gvm_connection_t *connection,
                               gsad_credentials_t *credentials, params_t *params,
-                              cmd_response_data_t *response_data)
+                              gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13145,7 +13151,7 @@ get_trash_report_configs_gmp (gvm_connection_t *connection,
 char *
 get_trash_report_formats_gmp (gvm_connection_t *connection,
                               gsad_credentials_t *credentials, params_t *params,
-                              cmd_response_data_t *response_data)
+                              gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13174,7 +13180,7 @@ get_trash_report_formats_gmp (gvm_connection_t *connection,
 char *
 get_trash_roles_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13202,7 +13208,7 @@ get_trash_roles_gmp (gvm_connection_t *connection,
 char *
 get_trash_scanners_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13230,7 +13236,7 @@ get_trash_scanners_gmp (gvm_connection_t *connection,
 char *
 get_trash_schedules_gmp (gvm_connection_t *connection,
                          gsad_credentials_t *credentials, params_t *params,
-                         cmd_response_data_t *response_data)
+                         gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13258,7 +13264,7 @@ get_trash_schedules_gmp (gvm_connection_t *connection,
 char *
 get_trash_tags_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13286,7 +13292,7 @@ get_trash_tags_gmp (gvm_connection_t *connection,
 char *
 get_trash_targets_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13314,7 +13320,7 @@ get_trash_targets_gmp (gvm_connection_t *connection,
 char *
 get_trash_tasks_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13342,7 +13348,7 @@ get_trash_tasks_gmp (gvm_connection_t *connection,
 char *
 get_trash_tickets_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13370,7 +13376,7 @@ get_trash_tickets_gmp (gvm_connection_t *connection,
 char *
 get_trash_agent_group_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   GString *xml;
 
@@ -13403,7 +13409,7 @@ get_trash_agent_group_gmp (gvm_connection_t *connection,
 static int
 send_settings_filters (gvm_connection_t *connection, params_t *data,
                        params_t *changed, GString *xml, int *modify_failed_flag,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   if (data)
     {
@@ -13473,7 +13479,7 @@ char *
 save_my_settings_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
                       const gchar *accept_language,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   const char *lang, *text, *old_passwd, *passwd, *max;
   const char *details_fname, *list_fname, *report_fname;
@@ -14265,7 +14271,7 @@ save_my_settings_gmp (gvm_connection_t *connection,
 static char *
 get_group (gvm_connection_t *connection, gsad_credentials_t *credentials,
            params_t *params, const char *extra_xml,
-           cmd_response_data_t *response_data)
+           gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "group", credentials, params, extra_xml, NULL,
                   response_data);
@@ -14283,7 +14289,7 @@ get_group (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_group (connection, credentials, params, NULL, response_data);
 }
@@ -14300,7 +14306,7 @@ get_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_groups_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "groups", credentials, params, NULL,
                    response_data);
@@ -14318,7 +14324,7 @@ get_groups_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 delete_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "group", credentials, params,
                                  response_data);
@@ -14336,7 +14342,7 @@ delete_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html, *command, *specials_element;
   const char *name, *comment, *users, *grant_full;
@@ -14434,7 +14440,7 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "group", credentials, params,
                           response_data);
@@ -14454,7 +14460,7 @@ export_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_groups_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "group", credentials, params, response_data);
 }
@@ -14471,7 +14477,7 @@ export_groups_gmp (gvm_connection_t *connection,
  */
 char *
 save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -14554,7 +14560,7 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_permission (gvm_connection_t *connection, gsad_credentials_t *credentials,
                 params_t *params, const char *extra_xml,
-                cmd_response_data_t *response_data)
+                gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -14578,7 +14584,7 @@ get_permission (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_permission_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return get_permission (connection, credentials, params, NULL, response_data);
 }
@@ -14596,7 +14602,7 @@ get_permission_gmp (gvm_connection_t *connection,
 char *
 get_permissions_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "permissions", credentials, params, NULL,
                    response_data);
@@ -14615,7 +14621,7 @@ get_permissions_gmp (gvm_connection_t *connection,
 char *
 delete_permission_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "permission", credentials, params,
                                  response_data);
@@ -14634,7 +14640,7 @@ delete_permission_gmp (gvm_connection_t *connection,
 char *
 create_permission_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -14788,7 +14794,7 @@ create_permission_gmp (gvm_connection_t *connection,
 char *
 create_permissions_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html, *summary_response;
@@ -15140,7 +15146,7 @@ create_permissions_gmp (gvm_connection_t *connection,
 char *
 export_permission_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "permission", credentials, params,
                           response_data);
@@ -15160,7 +15166,7 @@ export_permission_gmp (gvm_connection_t *connection,
 char *
 export_permissions_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "permission", credentials, params,
                       response_data);
@@ -15179,7 +15185,7 @@ export_permissions_gmp (gvm_connection_t *connection,
 char *
 save_permission_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *permission_id, *name, *comment, *resource_id, *resource_type;
@@ -15283,7 +15289,7 @@ save_permission_gmp (gvm_connection_t *connection,
 char *
 create_port_list_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *name, *comment, *port_range, *from_file;
@@ -15363,7 +15369,7 @@ create_port_list_gmp (gvm_connection_t *connection,
 char *
 create_port_range_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -15445,7 +15451,7 @@ create_port_range_gmp (gvm_connection_t *connection,
 static char *
 get_port_list (gvm_connection_t *connection, gsad_credentials_t *credentials,
                params_t *params, const char *extra_xml,
-               cmd_response_data_t *response_data)
+               gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -15470,7 +15476,7 @@ get_port_list (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_port_list_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return get_port_list (connection, credentials, params, NULL, response_data);
 }
@@ -15488,7 +15494,7 @@ get_port_list_gmp (gvm_connection_t *connection,
 char *
 get_port_lists_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "port_lists", credentials, params, NULL,
                    response_data);
@@ -15507,7 +15513,7 @@ get_port_lists_gmp (gvm_connection_t *connection,
 char *
 save_port_list_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -15584,7 +15590,7 @@ save_port_list_gmp (gvm_connection_t *connection,
 char *
 delete_port_list_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "port_list", credentials, params,
                                  response_data);
@@ -15603,7 +15609,7 @@ delete_port_list_gmp (gvm_connection_t *connection,
 char *
 delete_port_range_gmp (gvm_connection_t *connection,
                        gsad_credentials_t *credentials, params_t *params,
-                       cmd_response_data_t *response_data)
+                       gsad_command_response_data_t *response_data)
 {
   return delete_resource (connection, "port_range", credentials, params, TRUE,
                           response_data);
@@ -15622,7 +15628,7 @@ delete_port_range_gmp (gvm_connection_t *connection,
 char *
 import_port_list_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   gchar *command, *html;
   entity_t entity;
@@ -15692,7 +15698,7 @@ import_port_list_gmp (gvm_connection_t *connection,
  */
 char *
 delete_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "role", credentials, params,
                                  response_data);
@@ -15710,7 +15716,7 @@ delete_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   char *ret;
   const char *name, *comment, *users;
@@ -15786,7 +15792,7 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 get_role (gvm_connection_t *connection, gsad_credentials_t *credentials,
           params_t *params, const char *extra_xml,
-          cmd_response_data_t *response_data)
+          gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "role", credentials, params, extra_xml, NULL,
                   response_data);
@@ -15804,7 +15810,7 @@ get_role (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_role (connection, credentials, params, NULL, response_data);
 }
@@ -15821,7 +15827,7 @@ get_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_roles_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "roles", credentials, params, NULL,
                    response_data);
@@ -15839,7 +15845,7 @@ get_roles_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "role", credentials, params,
                           response_data);
@@ -15858,7 +15864,7 @@ export_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_roles_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "role", credentials, params, response_data);
 }
@@ -15875,7 +15881,7 @@ export_roles_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -15956,7 +15962,7 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_feeds_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   char *text = NULL;
@@ -16024,7 +16030,7 @@ get_feeds_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 static char *
 sync_feed (gvm_connection_t *connection, gsad_credentials_t *credentials,
            params_t *params, const char *sync_cmd, const char *action,
-           const char *feed_name, cmd_response_data_t *response_data)
+           const char *feed_name, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   gchar *html, *msg;
@@ -16077,7 +16083,7 @@ sync_feed (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 sync_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   gchar *html, *msg;
@@ -16128,7 +16134,7 @@ sync_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 sync_feed_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return sync_feed (connection, credentials, params, "sync_feed",
                     "Synchronize Feed", "the NVT feed", response_data);
@@ -16146,7 +16152,7 @@ sync_feed_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 sync_scap_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return sync_feed (connection, credentials, params, "sync_scap",
                     "Synchronize Feed", "the SCAP feed", response_data);
@@ -16164,7 +16170,7 @@ sync_scap_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 sync_cert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return sync_feed (connection, credentials, params, "sync_cert",
                     "Synchronize CERT Feed", "the CERT feed", response_data);
@@ -16186,7 +16192,7 @@ sync_cert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_filter (gvm_connection_t *connection, gsad_credentials_t *credentials,
             params_t *params, const char *extra_xml,
-            cmd_response_data_t *response_data)
+            gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -16209,7 +16215,7 @@ get_filter (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_filter (connection, credentials, params, NULL, response_data);
 }
@@ -16226,7 +16232,7 @@ get_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_filters_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "filters", credentials, params, NULL,
                    response_data);
@@ -16245,7 +16251,7 @@ get_filters_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 create_filter_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   gchar *html;
   const char *name, *comment, *term, *type;
@@ -16320,7 +16326,7 @@ create_filter_gmp (gvm_connection_t *connection,
 char *
 delete_filter_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "filter", credentials, params,
                                  response_data);
@@ -16339,7 +16345,7 @@ delete_filter_gmp (gvm_connection_t *connection,
 char *
 export_filter_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "filter", credentials, params,
                           response_data);
@@ -16359,7 +16365,7 @@ export_filter_gmp (gvm_connection_t *connection,
 char *
 export_filters_gmp (gvm_connection_t *connection,
                     gsad_credentials_t *credentials, params_t *params,
-                    cmd_response_data_t *response_data)
+                    gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "filter", credentials, params, response_data);
 }
@@ -16376,7 +16382,7 @@ export_filters_gmp (gvm_connection_t *connection,
  */
 char *
 save_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   gchar *html;
@@ -16458,7 +16464,7 @@ save_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_schedule_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "schedule", credentials, params,
                           response_data);
@@ -16477,7 +16483,7 @@ export_schedule_gmp (gvm_connection_t *connection,
 char *
 export_schedules_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "schedule", credentials, params,
                       response_data);
@@ -16496,7 +16502,7 @@ export_schedules_gmp (gvm_connection_t *connection,
 char *
 save_schedule_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   const char *schedule_id, *name, *comment, *timezone, *icalendar;
@@ -16576,7 +16582,7 @@ save_schedule_gmp (gvm_connection_t *connection,
  */
 char *
 delete_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "user", credentials, params,
                                  response_data);
@@ -16596,7 +16602,7 @@ delete_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_user (gvm_connection_t *connection, gsad_credentials_t *credentials,
           params_t *params, const char *extra_xml,
-          cmd_response_data_t *response_data)
+          gsad_command_response_data_t *response_data)
 {
   gchar *html;
   GString *extra;
@@ -16665,7 +16671,7 @@ get_user (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-              params_t *params, cmd_response_data_t *response_data)
+              params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_user (connection, credentials, params, NULL, response_data);
 }
@@ -16682,7 +16688,7 @@ get_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_users_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "users", credentials, params, NULL,
                    response_data);
@@ -16700,7 +16706,7 @@ get_users_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *name, *password, *hosts, *hosts_allow;
   const char *auth_method, *comment;
@@ -16864,7 +16870,7 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_vulns_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "vulns", credentials, params, NULL,
                    response_data);
@@ -16873,7 +16879,7 @@ get_vulns_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 auth_settings_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   GString *xml;
   gchar *buf;
@@ -16947,7 +16953,7 @@ auth_settings_gmp (gvm_connection_t *connection,
  */
 char *
 save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html, *buf;
@@ -17175,7 +17181,7 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "user", credentials, params,
                           response_data);
@@ -17194,14 +17200,14 @@ export_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_users_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "user", credentials, params, response_data);
 }
 
 char *
 cvss_calculator (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   GString *xml;
   const char *cvss_av, *cvss_au, *cvss_ac, *cvss_c, *cvss_i, *cvss_a;
@@ -17301,7 +17307,7 @@ cvss_calculator (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   entity_t entity = NULL;
@@ -17433,7 +17439,7 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_settings_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   GString *xml;
   gchar *command;
@@ -17506,7 +17512,7 @@ get_settings_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   const gchar *setting_value = params_value (params, "setting_value");
   const gchar *setting_name = NULL;
@@ -17599,7 +17605,7 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
 char *
 get_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const gchar *setting_id = params_value (params, "setting_id");
   CHECK_VARIABLE_INVALID (setting_id, "Get Setting");
@@ -17657,7 +17663,7 @@ get_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
         params_t *params, const char *extra_xml,
-        cmd_response_data_t *response_data)
+        gsad_command_response_data_t *response_data)
 {
   GString *xml;
   const char *name = params_value (params, "name");
@@ -17757,7 +17763,7 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-            params_t *params, cmd_response_data_t *response_data)
+            params_t *params, gsad_command_response_data_t *response_data)
 {
   return wizard (connection, credentials, params, NULL, response_data);
 }
@@ -17776,7 +17782,7 @@ wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
             params_t *params, const char *extra_xml,
-            cmd_response_data_t *response_data)
+            gsad_command_response_data_t *response_data)
 {
   const char *name;
   int ret;
@@ -17883,7 +17889,7 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 wizard_get_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return wizard_get (connection, credentials, params, NULL, response_data);
 }
@@ -17900,7 +17906,7 @@ wizard_get_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const char *type;
   params_t *selected_ids;
@@ -18026,7 +18032,7 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 bulk_export_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   const gchar *type, *filter, *bulk_select;
   gchar *param_name;
@@ -18080,7 +18086,7 @@ bulk_export_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -18165,7 +18171,7 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_asset (gvm_connection_t *connection, gsad_credentials_t *credentials,
            params_t *params, const char *extra_xml,
-           cmd_response_data_t *response_data)
+           gsad_command_response_data_t *response_data)
 {
   const gchar *asset_type;
   gmp_arguments_t *arguments;
@@ -18210,7 +18216,7 @@ get_asset (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_asset (connection, credentials, params, NULL, response_data);
 }
@@ -18227,7 +18233,7 @@ get_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_assets_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   const char *asset_type;
@@ -18262,7 +18268,7 @@ get_assets_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   char *ret;
   const char *report_id, *filter;
@@ -18332,7 +18338,7 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *html, *resource_id;
   const char *next_id;
@@ -18418,7 +18424,7 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 export_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "asset", credentials, params,
                           response_data);
@@ -18438,7 +18444,7 @@ export_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 export_assets_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "asset", credentials, params, response_data);
 }
@@ -18455,7 +18461,7 @@ export_assets_gmp (gvm_connection_t *connection,
  */
 char *
 save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *html;
@@ -18528,7 +18534,7 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_tickets_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "tickets", credentials, params, NULL,
                    response_data);
@@ -18546,7 +18552,7 @@ get_tickets_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "ticket", credentials, params, NULL, NULL,
                   response_data);
@@ -18565,7 +18571,7 @@ get_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 create_ticket_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   const gchar *result_id, *user_id, *note;
@@ -18638,7 +18644,7 @@ create_ticket_gmp (gvm_connection_t *connection,
  */
 char *
 save_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   const gchar *ticket_id, *status, *open_note, *fixed_note, *closed_note;
@@ -18719,7 +18725,7 @@ save_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 delete_ticket_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "ticket", credentials, params,
                                  response_data);
@@ -18738,7 +18744,7 @@ delete_ticket_gmp (gvm_connection_t *connection,
 char *
 get_timezones_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   GString *xml;
@@ -18804,7 +18810,7 @@ get_timezones_gmp (gvm_connection_t *connection,
 char *
 get_tls_certificates_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments = gmp_arguments_new ();
   const char *include_certificate_data;
@@ -18835,7 +18841,7 @@ get_tls_certificates_gmp (gvm_connection_t *connection,
 char *
 get_tls_certificate_gmp (gvm_connection_t *connection,
                          gsad_credentials_t *credentials, params_t *params,
-                         cmd_response_data_t *response_data)
+                         gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments = gmp_arguments_new ();
   const char *include_certificate_data;
@@ -18866,7 +18872,7 @@ get_tls_certificate_gmp (gvm_connection_t *connection,
 char *
 create_tls_certificate_gmp (gvm_connection_t *connection,
                             gsad_credentials_t *credentials, params_t *params,
-                            cmd_response_data_t *response_data)
+                            gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   const gchar *name, *comment, *trust, *certificate_bin;
@@ -18949,7 +18955,7 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
 char *
 save_tls_certificate_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   const gchar *tls_certificate_id, *name, *comment, *trust, *certificate_bin;
@@ -19034,7 +19040,7 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
 char *
 delete_tls_certificate_gmp (gvm_connection_t *connection,
                             gsad_credentials_t *credentials, params_t *params,
-                            cmd_response_data_t *response_data)
+                            gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "tls_certificate", credentials,
                                  params, response_data);
@@ -19054,7 +19060,7 @@ delete_tls_certificate_gmp (gvm_connection_t *connection,
 static char *
 get_license (gvm_connection_t *connection, gsad_credentials_t *credentials,
              params_t *params, const char *extra_xml,
-             cmd_response_data_t *response_data)
+             gsad_command_response_data_t *response_data)
 {
   return get_entity (connection, "license", credentials, params, NULL,
                      response_data);
@@ -19072,7 +19078,7 @@ get_license (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, cmd_response_data_t *response_data)
+                 params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_license (connection, credentials, params, NULL, response_data);
 }
@@ -19089,7 +19095,7 @@ get_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   const char *file;
@@ -19166,7 +19172,7 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 change_password_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   const char *old_passwd, *passwd;
   gchar *passwd_64 = NULL;
@@ -19279,7 +19285,7 @@ change_password_gmp (gvm_connection_t *connection,
 char *
 get_agent_installers_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "agent_installers", credentials, params, NULL,
                    response_data);
@@ -19298,7 +19304,7 @@ get_agent_installers_gmp (gvm_connection_t *connection,
 char *
 get_agent_installer_gmp (gvm_connection_t *connection,
                          gsad_credentials_t *credentials, params_t *params,
-                         cmd_response_data_t *response_data)
+                         gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "agent_installer", credentials, params, NULL,
                   NULL, response_data);
@@ -19317,7 +19323,7 @@ get_agent_installer_gmp (gvm_connection_t *connection,
 char *
 get_agent_installer_file_gmp (gvm_connection_t *connection,
                               gsad_credentials_t *credentials, params_t *params,
-                              cmd_response_data_t *response_data)
+                              gsad_command_response_data_t *response_data)
 {
   const gchar *id = params_value (params, "agent_installer_id");
   entity_t entity = NULL;
@@ -19440,7 +19446,7 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
  */
 char *
 get_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-               params_t *params, cmd_response_data_t *response_data)
+               params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "agent", credentials, params, NULL, NULL,
                   response_data);
@@ -19458,7 +19464,7 @@ get_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 get_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, cmd_response_data_t *response_data)
+                params_t *params, gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "agents", credentials, params, NULL,
                    response_data);
@@ -19476,7 +19482,7 @@ get_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  */
 char *
 modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *xml, *format, *update_to_latest_tag;
   const char *authorized, *attempts, *delay_in_seconds, *bulk_size;
@@ -19696,10 +19702,9 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
  * @return Enveloped XML object.
  */
 char *
-modify_agent_control_scan_config_gmp (gvm_connection_t *connection,
-                                      gsad_credentials_t *credentials,
-                                      params_t *params,
-                                      cmd_response_data_t *response_data)
+modify_agent_control_scan_config_gmp (
+  gvm_connection_t *connection, gsad_credentials_t *credentials,
+  params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *xml, *format;
   const char *agent_control_id, *attempts, *delay_in_seconds;
@@ -19859,7 +19864,7 @@ modify_agent_control_scan_config_gmp (gvm_connection_t *connection,
  */
 char *
 delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   gchar *xml, *format;
   int ret;
@@ -19951,7 +19956,7 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_agent_groups_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "agent_groups", credentials, params, NULL,
                    response_data);
@@ -19970,7 +19975,7 @@ get_agent_groups_gmp (gvm_connection_t *connection,
 char *
 get_agent_group_gmp (gvm_connection_t *connection,
                      gsad_credentials_t *credentials, params_t *params,
-                     cmd_response_data_t *response_data)
+                     gsad_command_response_data_t *response_data)
 {
   return get_one (connection, "agent_group", credentials, params, NULL, NULL,
                   response_data);
@@ -19989,7 +19994,7 @@ get_agent_group_gmp (gvm_connection_t *connection,
 char *
 create_agent_group_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   gchar *command = NULL, *html = NULL;
   GString *agents_element = NULL, *cmd = NULL;
@@ -20101,7 +20106,7 @@ create_agent_group_gmp (gvm_connection_t *connection,
 char *
 save_agent_group_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   gchar *html = NULL, *format = NULL;
   const char *agent_group_id = NULL, *name = NULL, *comment = NULL;
@@ -20203,7 +20208,7 @@ save_agent_group_gmp (gvm_connection_t *connection,
 char *
 delete_agent_group_gmp (gvm_connection_t *connection,
                         gsad_credentials_t *credentials, params_t *params,
-                        cmd_response_data_t *response_data)
+                        gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "agent_group", credentials, params,
                                  response_data);
@@ -20212,7 +20217,7 @@ delete_agent_group_gmp (gvm_connection_t *connection,
 char *
 renew_session_gmp (gvm_connection_t *connection,
                    gsad_credentials_t *credentials, params_t *params,
-                   cmd_response_data_t *response_data)
+                   gsad_command_response_data_t *response_data)
 {
   gchar *html;
   gchar *message;
@@ -20241,7 +20246,7 @@ renew_session_gmp (gvm_connection_t *connection,
 char *
 get_oci_image_target_gmp (gvm_connection_t *connection,
                           gsad_credentials_t *credentials, params_t *params,
-                          cmd_response_data_t *response_data)
+                          gsad_command_response_data_t *response_data)
 {
   gmp_arguments_t *arguments;
   arguments = gmp_arguments_new ();
@@ -20265,7 +20270,7 @@ get_oci_image_target_gmp (gvm_connection_t *connection,
 char *
 get_oci_image_targets_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   return get_many (connection, "oci_image_targets", credentials, params, NULL,
                    response_data);
@@ -20285,7 +20290,7 @@ get_oci_image_targets_gmp (gvm_connection_t *connection,
 char *
 export_oci_image_target_gmp (gvm_connection_t *connection,
                              gsad_credentials_t *credentials, params_t *params,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   return export_resource (connection, "oci_image_target", credentials, params,
                           response_data);
@@ -20305,7 +20310,7 @@ export_oci_image_target_gmp (gvm_connection_t *connection,
 char *
 export_oci_image_targets_gmp (gvm_connection_t *connection,
                               gsad_credentials_t *credentials, params_t *params,
-                              cmd_response_data_t *response_data)
+                              gsad_command_response_data_t *response_data)
 {
   return export_many (connection, "oci_image_target", credentials, params,
                       response_data);
@@ -20324,7 +20329,7 @@ export_oci_image_targets_gmp (gvm_connection_t *connection,
 char *
 create_oci_image_target_gmp (gvm_connection_t *connection,
                              gsad_credentials_t *credentials, params_t *params,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   int ret;
   gchar *xml;
@@ -20464,7 +20469,7 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
 char *
 delete_oci_image_target_gmp (gvm_connection_t *connection,
                              gsad_credentials_t *credentials, params_t *params,
-                             cmd_response_data_t *response_data)
+                             gsad_command_response_data_t *response_data)
 {
   return move_resource_to_trash (connection, "oci_image_target", credentials,
                                  params, response_data);
@@ -20483,7 +20488,7 @@ delete_oci_image_target_gmp (gvm_connection_t *connection,
 char *
 save_oci_image_target_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   entity_t entity;
   const char *name, *comment, *image_references, *exclude_images = NULL;
@@ -20670,7 +20675,7 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
  */
 char *
 ping_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-          params_t *params, cmd_response_data_t *response_data)
+          params_t *params, gsad_command_response_data_t *response_data)
 {
   return action_result (connection, credentials, params, response_data, "ping",
                         "pong", NULL, NULL);
@@ -20679,7 +20684,7 @@ ping_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 char *
 get_capabilities_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      cmd_response_data_t *response_data)
+                      gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   GString *xml;
@@ -20738,7 +20743,7 @@ get_capabilities_gmp (gvm_connection_t *connection,
 
 char *
 get_features_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                  params_t *params, cmd_response_data_t *response_data)
+                  params_t *params, gsad_command_response_data_t *response_data)
 {
   entity_t entity = NULL;
   GString *xml;
@@ -20988,7 +20993,7 @@ logout_gmp (const gchar *username, const gchar *password)
  */
 int
 login (gsad_http_connection_t *con, params_t *params,
-       cmd_response_data_t *response_data, const char *client_address)
+       gsad_command_response_data_t *response_data, const char *client_address)
 {
   int ret, status;
   gsad_authentication_reason_t auth_reason;

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -399,8 +399,8 @@ check_modify_config (gvm_connection_t *connection,
 
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a config. "
@@ -415,8 +415,8 @@ check_modify_config (gvm_connection_t *connection,
   if (status_text == NULL)
     {
       free_entity (entity);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a config. "
@@ -428,7 +428,8 @@ check_modify_config (gvm_connection_t *connection,
     {
       const char *message = "A config with the given name exists already.";
 
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       response = action_result (connection, credentials, params, response_data,
                                 "Save Config", message, NULL, NULL);
 
@@ -480,18 +481,21 @@ set_http_status_from_entity (entity_t entity,
                              gsad_command_response_data_t *response_data)
 {
   if (entity == NULL)
-    cmd_response_data_set_status_code (response_data,
-                                       MHD_HTTP_INTERNAL_SERVER_ERROR);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_INTERNAL_SERVER_ERROR);
   else if (str_equal (entity_attribute (entity, "status_text"),
                       "Permission denied"))
-    cmd_response_data_set_status_code (response_data, MHD_HTTP_FORBIDDEN);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_FORBIDDEN);
   else if (str_equal (entity_attribute (entity, "status"), "404"))
-    cmd_response_data_set_status_code (response_data, MHD_HTTP_NOT_FOUND);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_NOT_FOUND);
   else if (str_equal (entity_attribute (entity, "status"), "503"))
-    cmd_response_data_set_status_code (response_data,
-                                       MHD_HTTP_SERVICE_UNAVAILABLE);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_SERVICE_UNAVAILABLE);
   else
-    cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+    gsad_command_response_data_set_status_code (response_data,
+                                                MHD_HTTP_BAD_REQUEST);
 }
 
 /**
@@ -695,8 +699,8 @@ message_invalid (gvm_connection_t *connection, gsad_credentials_t *credentials,
   gchar *ret = action_result (connection, credentials, params, response_data,
                               op_name, message, NULL, NULL);
 
-  cmd_response_data_set_status_code (response_data,
-                                     GSAD_STATUS_INVALID_REQUEST);
+  gsad_command_response_data_set_status_code (response_data,
+                                              GSAD_STATUS_INVALID_REQUEST);
 
   return ret;
 }
@@ -779,8 +783,8 @@ get_entity (gvm_connection_t *connection, const char *type,
 
       gmp_arguments_free (arguments);
 
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a resource list. "
@@ -796,8 +800,8 @@ get_entity (gvm_connection_t *connection, const char *type,
       g_string_free (xml, TRUE);
       g_free (cmd);
 
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting resources list. "
@@ -912,8 +916,8 @@ get_entities (gvm_connection_t *connection, const char *type,
 
       gmp_arguments_free (arguments);
 
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a resource list. "
@@ -932,8 +936,8 @@ get_entities (gvm_connection_t *connection, const char *type,
       g_free (cmd);
       g_string_free (xml, TRUE);
 
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting resources list. "
@@ -1156,8 +1160,8 @@ export_resource (gvm_connection_t *connection, const char *type,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a resource. "
@@ -1170,8 +1174,8 @@ export_resource (gvm_connection_t *connection, const char *type,
   if (read_entity_and_text_c (connection, &entity, &content))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a resource. "
@@ -1190,8 +1194,8 @@ export_resource (gvm_connection_t *connection, const char *type,
       g_free (content);
       free_entity (entity);
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a resource. "
@@ -1207,8 +1211,8 @@ export_resource (gvm_connection_t *connection, const char *type,
       g_free (content);
       free_entity (entity);
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       switch (ret)
         {
         case 1:
@@ -1300,8 +1304,8 @@ export_many (gvm_connection_t *connection, const char *type,
           == -1)
         {
           g_free (filter_escaped);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a list. "
@@ -1323,8 +1327,8 @@ export_many (gvm_connection_t *connection, const char *type,
           == -1)
         {
           g_free (filter_escaped);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a list. "
@@ -1344,8 +1348,8 @@ export_many (gvm_connection_t *connection, const char *type,
           == -1)
         {
           g_free (filter_escaped);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a list. "
@@ -1359,8 +1363,8 @@ export_many (gvm_connection_t *connection, const char *type,
   entity = NULL;
   if (read_entity_and_text_c (connection, &entity, &content))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a list. "
@@ -1378,8 +1382,8 @@ export_many (gvm_connection_t *connection, const char *type,
     {
       g_free (content);
       free_entity (entity);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       switch (ret)
         {
         case 1:
@@ -1463,7 +1467,8 @@ delete_resource (gvm_connection_t *connection, const char *type,
   else
     {
       g_free (id_name);
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting a resource. "
@@ -1501,8 +1506,8 @@ delete_resource (gvm_connection_t *connection, const char *type,
     {
       g_free (resource_id);
       g_free (extra_attribs);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting a resource. "
@@ -1517,8 +1522,8 @@ delete_resource (gvm_connection_t *connection, const char *type,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting a resource. "
@@ -1626,7 +1631,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Required parameter %s was NULL.",
         param_name);
       g_free (param_name);
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       html =
         gsad_http_create_gsad_message (credentials, message, response_data);
       g_free (message);
@@ -1642,8 +1648,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while performing an action. "
@@ -1651,8 +1657,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while performing an action. "
@@ -1660,8 +1666,8 @@ resource_action (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while performing an action. "
@@ -1790,8 +1796,8 @@ create_report_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new report. "
@@ -1799,8 +1805,8 @@ create_report_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new report. "
@@ -1808,8 +1814,8 @@ create_report_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new report. "
@@ -1867,8 +1873,8 @@ create_import_task_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating an import task. "
@@ -1876,8 +1882,8 @@ create_import_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating an import task. "
@@ -1885,8 +1891,8 @@ create_import_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating an import task. "
@@ -2105,8 +2111,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new task. "
@@ -2114,8 +2120,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new task. "
@@ -2123,8 +2129,8 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new task. "
@@ -2159,7 +2165,7 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               break;
             case 1:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2169,7 +2175,7 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                 response_data);
             case 2:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2179,7 +2185,7 @@ create_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                 response_data);
             default:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2356,8 +2362,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new agent-group task. "
@@ -2365,8 +2371,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new agent-group task. "
@@ -2374,8 +2380,8 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new agent-group task. "
@@ -2410,7 +2416,7 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
               break;
             case 1:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2420,7 +2426,7 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
                 response_data);
             case 2:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2430,7 +2436,7 @@ create_agent_group_task_gmp (gvm_connection_t *connection,
                 response_data);
             default:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2607,8 +2613,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new oci image task. "
@@ -2616,8 +2622,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new oci image task. "
@@ -2625,8 +2631,8 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new oci image task. "
@@ -2661,7 +2667,7 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
               break;
             case 1:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2671,7 +2677,7 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
                 response_data);
             case 2:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2681,7 +2687,7 @@ create_oci_image_task_gmp (gvm_connection_t *connection,
                 response_data);
             default:
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -2925,8 +2931,8 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a task. "
@@ -2934,8 +2940,8 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a task. "
@@ -2943,8 +2949,8 @@ save_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a task. "
@@ -3024,8 +3030,8 @@ save_import_task_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an import task. "
@@ -3033,8 +3039,8 @@ save_import_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an import task. "
@@ -3042,8 +3048,8 @@ save_import_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an import task. "
@@ -3152,8 +3158,8 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent-group task. "
@@ -3161,8 +3167,8 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent-group task. "
@@ -3170,8 +3176,8 @@ save_agent_group_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent-group task. "
@@ -3300,8 +3306,8 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an oci image task. "
@@ -3309,8 +3315,8 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an oci image task. "
@@ -3318,8 +3324,8 @@ save_oci_image_task_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an oci image task. "
@@ -3457,8 +3463,8 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while moving a task. "
@@ -3466,8 +3472,8 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while moving a task. "
@@ -3475,8 +3481,8 @@ move_task_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while moving a task. "
@@ -4035,8 +4041,8 @@ create_credential_gmp (gvm_connection_t *connection,
         }
       else
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while creating a new credential. "
@@ -4052,8 +4058,8 @@ create_credential_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new credential. "
@@ -4061,8 +4067,8 @@ create_credential_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new credential. "
@@ -4070,8 +4076,8 @@ create_credential_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new credential. "
@@ -4168,8 +4174,8 @@ download_credential_gmp (gvm_connection_t *connection,
                             credential_id, format)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a credential. "
@@ -4185,8 +4191,8 @@ download_credential_gmp (gvm_connection_t *connection,
       /* A base64 encoded package. */
       if (read_entity_c (connection, &entity))
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a credential. "
@@ -4222,8 +4228,8 @@ download_credential_gmp (gvm_connection_t *connection,
       else
         {
           free_entity (entity);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a credential. "
@@ -4239,8 +4245,8 @@ download_credential_gmp (gvm_connection_t *connection,
       /* A key or certificate. */
       if (read_entity_c (connection, &entity))
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a credential. "
@@ -4270,8 +4276,8 @@ download_credential_gmp (gvm_connection_t *connection,
         }
       else
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           free_entity (entity);
           return gsad_http_create_gsad_message (
             credentials,
@@ -4567,8 +4573,8 @@ modify_credential_store_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a credential store. "
@@ -4576,8 +4582,8 @@ modify_credential_store_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a credential store. "
@@ -4585,8 +4591,8 @@ modify_credential_store_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a credential store. "
@@ -4633,8 +4639,8 @@ verify_credential_store_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while verifying a credential store. "
@@ -4642,8 +4648,8 @@ verify_credential_store_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while verifying a credential store. "
@@ -4651,8 +4657,8 @@ verify_credential_store_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while verifying a credential store. "
@@ -5002,8 +5008,8 @@ save_credential_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Credential. "
@@ -5011,8 +5017,8 @@ save_credential_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Credential. "
@@ -5020,8 +5026,8 @@ save_credential_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Credential. "
@@ -5206,24 +5212,24 @@ get_aggregate_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting aggregates. "
@@ -5280,8 +5286,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Report "
@@ -5289,8 +5295,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Report "
@@ -5298,8 +5304,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Report "
@@ -5323,8 +5329,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         case 0:
           break;
         case 1:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting Report "
@@ -5332,8 +5338,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting Report "
@@ -5341,8 +5347,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting Report "
@@ -5366,8 +5372,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Report "
@@ -5376,8 +5382,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Report "
@@ -5385,8 +5391,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Report "
@@ -5410,8 +5416,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Tasks"
@@ -5420,8 +5426,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Tasks"
@@ -5429,8 +5435,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting Tasks"
@@ -5454,8 +5460,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting"
@@ -5464,8 +5470,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting"
@@ -5473,8 +5479,8 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting"
@@ -5871,8 +5877,8 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new alert. "
@@ -5880,8 +5886,8 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new alert. "
@@ -5889,8 +5895,8 @@ create_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new alert. "
@@ -6011,7 +6017,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (alert_id == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while editing an alert. "
@@ -6030,8 +6037,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
                             alert_id)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting alert info. "
@@ -6056,8 +6063,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (read_string_c (connection, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting alert info. "
@@ -6074,8 +6081,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           == -1)
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting report formats. "
@@ -6087,8 +6094,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
       if (read_string_c (connection, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting report formats. "
@@ -6107,8 +6114,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           == -1)
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting report configs. "
@@ -6120,8 +6127,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
       if (read_string_c (connection, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting report configs. "
@@ -6139,8 +6146,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           == -1)
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting the list "
@@ -6153,8 +6160,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
       if (read_string_c (connection, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting the list "
@@ -6177,8 +6184,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           == -1)
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting the list "
@@ -6191,8 +6198,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
       if (read_string_c (connection, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting the list "
@@ -6214,8 +6221,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
           == -1)
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting the list "
@@ -6228,8 +6235,8 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
       if (read_string_c (connection, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting the list "
@@ -6370,8 +6377,8 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a new alert. "
@@ -6379,8 +6386,8 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a new alert. "
@@ -6388,8 +6395,8 @@ save_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a new alert. "
@@ -6426,8 +6433,8 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (alert_id == NULL)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         GSAD_STATUS_INVALID_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  GSAD_STATUS_INVALID_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "Missing parameter alert_id."
@@ -6441,8 +6448,8 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                             alert_id)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while testing an alert. "
@@ -6453,8 +6460,8 @@ test_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while testing an alert. "
@@ -6735,8 +6742,8 @@ create_target_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new target. "
@@ -6744,8 +6751,8 @@ create_target_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new target. "
@@ -6753,8 +6760,8 @@ create_target_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new target. "
@@ -6808,8 +6815,8 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                 type, id, type)
           == -1)
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while cloning a resource. "
@@ -6825,8 +6832,8 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                  type, id, type)
            == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while cloning a resource. "
@@ -6838,8 +6845,8 @@ clone_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while cloning a resource. "
@@ -6906,8 +6913,8 @@ restore_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                             target_id)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while restoring a resource. "
@@ -6918,8 +6925,8 @@ restore_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (read_entity_and_string_c (connection, &entity, NULL))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while restoring a resource. "
@@ -6958,8 +6965,8 @@ empty_trashcan_gmp (gvm_connection_t *connection,
 
   if (gvm_connection_sendf (connection, "<empty_trashcan/>") == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while emptying the trashcan. "
@@ -6969,8 +6976,8 @@ empty_trashcan_gmp (gvm_connection_t *connection,
 
   if (read_entity_and_string_c (connection, &entity, NULL))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while emptying the trashcan. "
@@ -7060,8 +7067,8 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_http_create_gsad_message (
         credentials,
@@ -7070,8 +7077,8 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_http_create_gsad_message (
         credentials,
@@ -7080,8 +7087,8 @@ create_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_http_create_gsad_message (
         credentials,
@@ -7200,8 +7207,8 @@ save_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_http_create_gsad_message (
         credentials,
@@ -7211,8 +7218,8 @@ save_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_http_create_gsad_message (
         credentials,
@@ -7223,8 +7230,8 @@ save_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_http_create_gsad_message (
         credentials,
@@ -7369,8 +7376,8 @@ toggle_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                             tag_id, enable)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying a tag. "
@@ -7383,8 +7390,8 @@ toggle_tag_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying a tag. "
@@ -7695,8 +7702,8 @@ save_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying target. "
@@ -7708,8 +7715,8 @@ save_target_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying a target. "
@@ -7812,8 +7819,8 @@ create_config_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new config. "
@@ -7821,8 +7828,8 @@ create_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new config. "
@@ -7830,8 +7837,8 @@ create_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new config. "
@@ -7883,8 +7890,8 @@ import_config_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a config. "
@@ -7892,8 +7899,8 @@ import_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a config. "
@@ -7901,8 +7908,8 @@ import_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a config. "
@@ -8027,8 +8034,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (gmp_ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a config. "
@@ -8074,7 +8081,7 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               == -1)
             {
               g_free (value);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -8113,8 +8120,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
               && strcmp (params_value (params, "trend"), "0"))
           == -1)
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving a config. "
@@ -8141,7 +8148,7 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                       trends && member1 (trends, family))
                 == -1)
               {
-                cmd_response_data_set_status_code (
+                gsad_command_response_data_set_status_code (
                   response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                 return gsad_http_create_gsad_message (
                   credentials,
@@ -8176,7 +8183,7 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                         family)
                   == -1)
                 {
-                  cmd_response_data_set_status_code (
+                  gsad_command_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   return gsad_http_create_gsad_message (
                     credentials,
@@ -8192,8 +8199,8 @@ save_config_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                             "</modify_config>")
           == -1)
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving a config. "
@@ -8253,8 +8260,8 @@ get_config_family (gvm_connection_t *connection,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting list of configs. "
@@ -8266,8 +8273,8 @@ get_config_family (gvm_connection_t *connection,
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting list of configs. "
@@ -8372,8 +8379,8 @@ edit_config_family_all_gmp (gvm_connection_t *connection,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting list of configs. "
@@ -8385,8 +8392,8 @@ edit_config_family_all_gmp (gvm_connection_t *connection,
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting list of configs. "
@@ -8441,8 +8448,8 @@ save_config_family_gmp (gvm_connection_t *connection,
                             config_id, family)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a config. "
@@ -8462,8 +8469,8 @@ save_config_family_gmp (gvm_connection_t *connection,
       while (params_iterator_next (&iter, &name, &param))
         if (gvm_connection_sendf (connection, "<nvt oid=\"%s\"/>", name) == -1)
           {
-            cmd_response_data_set_status_code (response_data,
-                                               MHD_HTTP_INTERNAL_SERVER_ERROR);
+            gsad_command_response_data_set_status_code (
+              response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
             return gsad_http_create_gsad_message (
               credentials,
               "An internal error occurred while saving a config. "
@@ -8477,8 +8484,8 @@ save_config_family_gmp (gvm_connection_t *connection,
                                         "</modify_config>")
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a config. "
@@ -8533,8 +8540,8 @@ get_config_nvt_gmp (gvm_connection_t *connection,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting list of configs. "
@@ -8546,8 +8553,8 @@ get_config_nvt_gmp (gvm_connection_t *connection,
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting list of configs. "
@@ -8714,8 +8721,8 @@ save_config_nvt_gmp (gvm_connection_t *connection,
               if (timeout == NULL)
                 {
                   g_free (value);
-                  cmd_response_data_set_status_code (response_data,
-                                                     MHD_HTTP_BAD_REQUEST);
+                  gsad_command_response_data_set_status_code (
+                    response_data, MHD_HTTP_BAD_REQUEST);
                   return gsad_http_create_gsad_message (
                     credentials,
                     "An internal error occurred while saving a config. "
@@ -8774,7 +8781,7 @@ save_config_nvt_gmp (gvm_connection_t *connection,
           if (ret == -1)
             {
               g_free (value);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -9015,8 +9022,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a preference file. "
@@ -9029,8 +9036,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
   if (read_entity_c (connection, &entity))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a preference file. "
@@ -9058,8 +9065,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
     {
       free_entity (entity);
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a preference file. "
@@ -9240,8 +9247,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a report. "
@@ -9259,7 +9266,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
           if (read_entity_c (connection, &entity))
             {
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -9272,7 +9279,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
           if (report == NULL)
             {
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -9295,7 +9302,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                   switch (ret)
                     {
                     case 1:
-                      cmd_response_data_set_status_code (
+                      gsad_command_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                       return gsad_http_create_gsad_message (
                         credentials,
@@ -9305,7 +9312,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                         "daemon.",
                         response_data);
                     case 2:
-                      cmd_response_data_set_status_code (
+                      gsad_command_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                       return gsad_http_create_gsad_message (
                         credentials,
@@ -9315,7 +9322,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                         "daemon.",
                         response_data);
                     default:
-                      cmd_response_data_set_status_code (
+                      gsad_command_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                       return gsad_http_create_gsad_message (
                         credentials,
@@ -9359,7 +9366,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
           entity = NULL;
           if (read_entity_c (connection, &entity))
             {
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -9405,7 +9412,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                       switch (ret)
                         {
                         case 1:
-                          cmd_response_data_set_status_code (
+                          gsad_command_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                           return gsad_http_create_gsad_message (
                             credentials,
@@ -9416,7 +9423,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                             "daemon.",
                             response_data);
                         case 2:
-                          cmd_response_data_set_status_code (
+                          gsad_command_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                           return gsad_http_create_gsad_message (
                             credentials,
@@ -9427,7 +9434,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                             "manager daemon.",
                             response_data);
                         default:
-                          cmd_response_data_set_status_code (
+                          gsad_command_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                           return gsad_http_create_gsad_message (
                             credentials,
@@ -9469,7 +9476,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
           else
             {
               free_entity (entity);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -9496,7 +9503,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
           entity = NULL;
           if (read_entity_and_string_c (connection, &entity, &xml))
             {
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -9555,8 +9562,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
       if (read_string_c (connection, &xml))
         {
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while getting a report. "
@@ -9636,8 +9643,8 @@ get_report_errors_gmp (gvm_connection_t *connection,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report errors. "
@@ -9651,8 +9658,8 @@ get_report_errors_gmp (gvm_connection_t *connection,
   entity = NULL;
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report errors. "
@@ -9732,8 +9739,8 @@ get_report_hosts_gmp (gvm_connection_t *connection,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report hosts. "
@@ -9747,8 +9754,8 @@ get_report_hosts_gmp (gvm_connection_t *connection,
   entity = NULL;
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report hosts. "
@@ -9826,8 +9833,8 @@ get_report_ports_gmp (gvm_connection_t *connection,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report ports. "
@@ -9841,8 +9848,8 @@ get_report_ports_gmp (gvm_connection_t *connection,
   entity = NULL;
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report ports. "
@@ -9921,8 +9928,8 @@ get_report_tls_certificates_gmp (gvm_connection_t *connection,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report TLS certificates. "
@@ -9936,8 +9943,8 @@ get_report_tls_certificates_gmp (gvm_connection_t *connection,
   entity = NULL;
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting report TLS certificates. "
@@ -9993,7 +10000,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if ((alert_id == NULL) || (report_id == NULL))
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "Missing parameter alert_id or report_id. "
@@ -10019,8 +10027,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                   report_id, filter ? filter : "", alert_id);
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a report. "
@@ -10031,8 +10039,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a report. "
@@ -10046,8 +10054,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if ((status == NULL) || (strlen (status) == 0))
     {
       free_entity (entity);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting a report. "
@@ -10058,7 +10066,8 @@ report_alert_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (strcmp (status, "200"))
     {
       free_entity (entity);
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "Running the report alert failed."
@@ -10155,7 +10164,8 @@ download_ssl_cert (gvm_connection_t *connection,
   ssl_cert = params_value (params, "ssl_cert");
   if (ssl_cert == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (credentials,
                                             "An internal error occurred."
                                             " Diagnostics: ssl_cert was NULL.",
@@ -10194,7 +10204,8 @@ download_ca_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
   ca_pub = params_value (params, "ca_pub");
   if (ca_pub == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (credentials,
                                             "An internal error occurred."
                                             " Diagnostics: ca_pub was NULL.",
@@ -10226,7 +10237,8 @@ download_key_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
   key_pub = params_value (params, "key_pub");
   if (key_pub == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (credentials,
                                             "An internal error occurred."
                                             " Diagnostics: key_pub was NULL.",
@@ -10575,8 +10587,8 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new note. "
@@ -10584,8 +10596,8 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new note. "
@@ -10593,8 +10605,8 @@ create_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new note. "
@@ -10693,8 +10705,8 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a note. "
@@ -10702,8 +10714,8 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a note. "
@@ -10711,8 +10723,8 @@ save_note_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a note. "
@@ -10877,8 +10889,8 @@ create_override_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new override. "
@@ -10886,8 +10898,8 @@ create_override_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new override. "
@@ -10895,8 +10907,8 @@ create_override_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new override. "
@@ -11006,8 +11018,8 @@ save_override_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a override. "
@@ -11015,8 +11027,8 @@ save_override_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a override. "
@@ -11024,8 +11036,8 @@ save_override_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a override. "
@@ -11168,8 +11180,8 @@ verify_scanner_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while verifying a scanner. "
@@ -11177,8 +11189,8 @@ verify_scanner_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while verifying a scanner. "
@@ -11186,8 +11198,8 @@ verify_scanner_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while verifying a scanner. "
@@ -11266,8 +11278,8 @@ create_scanner_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new scanner. "
@@ -11275,8 +11287,8 @@ create_scanner_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new scanner. "
@@ -11284,8 +11296,8 @@ create_scanner_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new scanner. "
@@ -11393,8 +11405,8 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a scanner. "
@@ -11402,8 +11414,8 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a scanner. "
@@ -11411,8 +11423,8 @@ save_scanner_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a scanner. "
@@ -11535,8 +11547,8 @@ create_schedule_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new schedule. "
@@ -11544,8 +11556,8 @@ create_schedule_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new schedule. "
@@ -11553,8 +11565,8 @@ create_schedule_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new schedule. "
@@ -11621,8 +11633,8 @@ get_system_reports_gmp (gvm_connection_t *connection,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the system reports. "
@@ -11634,8 +11646,8 @@ get_system_reports_gmp (gvm_connection_t *connection,
   if (read_string_c (connection, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the system reports. "
@@ -11711,8 +11723,8 @@ get_system_report_gmp (gvm_connection_t *connection,
     {
       g_string_free (xml, TRUE);
       g_free (gmp_command);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the system reports. "
@@ -11725,8 +11737,8 @@ get_system_report_gmp (gvm_connection_t *connection,
     {
       g_string_free (xml, TRUE);
       g_free (gmp_command);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the system reports. "
@@ -12092,8 +12104,8 @@ create_report_config_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a Report Config. "
@@ -12101,8 +12113,8 @@ create_report_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a Report Config. "
@@ -12110,8 +12122,8 @@ create_report_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a Report Config. "
@@ -12202,8 +12214,8 @@ save_report_config_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Report Config. "
@@ -12211,8 +12223,8 @@ save_report_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Report Config. "
@@ -12220,8 +12232,8 @@ save_report_config_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Report Config. "
@@ -12356,8 +12368,8 @@ import_report_format_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a report format. "
@@ -12365,8 +12377,8 @@ import_report_format_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a report format. "
@@ -12374,8 +12386,8 @@ import_report_format_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a report format. "
@@ -12499,7 +12511,7 @@ save_report_format_gmp (gvm_connection_t *connection,
             case 0:
               break;
             case 1:
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -12508,7 +12520,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                 "Diagnostics: Failure to send command to manager daemon.",
                 response_data);
             case 2:
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -12518,7 +12530,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                 "Diagnostics: Failure to receive response from manager daemon.",
                 response_data);
             default:
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -12577,7 +12589,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                 case 0:
                   break;
                 case 1:
-                  cmd_response_data_set_status_code (
+                  gsad_command_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
                   return gsad_http_create_gsad_message (
@@ -12587,7 +12599,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                     "Diagnostics: Failure to send command to manager daemon.",
                     response_data);
                 case 2:
-                  cmd_response_data_set_status_code (
+                  gsad_command_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
                   return gsad_http_create_gsad_message (
@@ -12599,7 +12611,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                     "daemon.",
                     response_data);
                 default:
-                  cmd_response_data_set_status_code (
+                  gsad_command_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
                   return gsad_http_create_gsad_message (
@@ -12632,8 +12644,8 @@ save_report_format_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Report Format. "
@@ -12641,8 +12653,8 @@ save_report_format_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Report Format. "
@@ -12650,8 +12662,8 @@ save_report_format_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Report Format. "
@@ -12726,7 +12738,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   name = params_value (params, "name");
   if (name == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while trying to start a wizard. "
@@ -12763,8 +12776,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while running a wizard. "
@@ -12772,8 +12785,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while running a wizard. "
@@ -12781,8 +12794,8 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while running a wizard. "
@@ -12797,38 +12810,38 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   return html;
 }
 
-#define GET_TRASH_RESOURCE(capability, command, name)                         \
-  if (command_enabled (credentials, capability))                              \
-    {                                                                         \
-      if (gvm_connection_sendf (connection,                                   \
-                                "<" command " filter=\"rows=-1 sort=name\""   \
-                                " trash=\"1\"/>")                             \
-          == -1)                                                              \
-        {                                                                     \
-          g_string_free (xml, TRUE);                                          \
-          cmd_response_data_set_status_code (response_data,                   \
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR); \
-          return gsad_http_create_gsad_message (                              \
-            credentials,                                                      \
-            "An internal error occurred while getting " name                  \
-            " list for trash."                                                \
-            "Diagnostics: Failure to send command to"                         \
-            " manager daemon.",                                               \
-            response_data);                                                   \
-        }                                                                     \
-                                                                              \
-      if (read_string_c (connection, &xml))                                   \
-        {                                                                     \
-          g_string_free (xml, TRUE);                                          \
-          cmd_response_data_set_status_code (response_data,                   \
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR); \
-          return gsad_http_create_gsad_message (                              \
-            credentials,                                                      \
-            "An internal error occurred while getting " name " list."         \
-            "Diagnostics: Failure to receive response from"                   \
-            " manager daemon.",                                               \
-            response_data);                                                   \
-        }                                                                     \
+#define GET_TRASH_RESOURCE(capability, command, name)                       \
+  if (command_enabled (credentials, capability))                            \
+    {                                                                       \
+      if (gvm_connection_sendf (connection,                                 \
+                                "<" command " filter=\"rows=-1 sort=name\"" \
+                                " trash=\"1\"/>")                           \
+          == -1)                                                            \
+        {                                                                   \
+          g_string_free (xml, TRUE);                                        \
+          gsad_command_response_data_set_status_code (                      \
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                 \
+          return gsad_http_create_gsad_message (                            \
+            credentials,                                                    \
+            "An internal error occurred while getting " name                \
+            " list for trash."                                              \
+            "Diagnostics: Failure to send command to"                       \
+            " manager daemon.",                                             \
+            response_data);                                                 \
+        }                                                                   \
+                                                                            \
+      if (read_string_c (connection, &xml))                                 \
+        {                                                                   \
+          g_string_free (xml, TRUE);                                        \
+          gsad_command_response_data_set_status_code (                      \
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                 \
+          return gsad_http_create_gsad_message (                            \
+            credentials,                                                    \
+            "An internal error occurred while getting " name " list."       \
+            "Diagnostics: Failure to receive response from"                 \
+            " manager daemon.",                                             \
+            response_data);                                                 \
+        }                                                                   \
     }
 
 /**
@@ -13540,8 +13553,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
         case 0:
           break;
         case 1:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13549,8 +13562,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
             "Diagnostics: Manager closed connection during authenticate.",
             response_data);
         case 2:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "You tried to change your password, but the old"
@@ -13560,8 +13573,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
             " of your settings.",
             response_data);
         default:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13581,8 +13594,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (passwd_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13597,8 +13610,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13637,8 +13650,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (text_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13653,8 +13666,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13704,8 +13717,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (max_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13721,8 +13734,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13756,8 +13769,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (fname_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13773,8 +13786,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13807,8 +13820,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (fname_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13824,8 +13837,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13859,8 +13872,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (fname_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13876,8 +13889,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13910,8 +13923,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (lang_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13927,8 +13940,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -13955,8 +13968,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
   if (send_settings_filters (connection, defaults, changed, xml, &modify_failed,
                              response_data))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving settings. "
@@ -13971,8 +13984,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
   if (send_settings_filters (connection, filters, changed, xml, &modify_failed,
                              response_data))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving settings. "
@@ -14001,8 +14014,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (text_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14018,8 +14031,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14054,8 +14067,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (text_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14071,8 +14084,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14109,8 +14122,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
         {
           g_free (text_64);
           gvm_connection_close (connection);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14127,8 +14140,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
         {
           g_string_free (xml, TRUE);
           gvm_connection_close (connection);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14162,8 +14175,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (time_format_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14179,8 +14192,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14214,8 +14227,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
           == -1)
         {
           g_free (date_format_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14231,8 +14244,8 @@ save_my_settings_gmp (gvm_connection_t *connection,
       if (read_entity_and_string_c (connection, &entity, &xml))
         {
           g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving settings. "
@@ -14394,8 +14407,8 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new group. "
@@ -14403,8 +14416,8 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new group. "
@@ -14412,8 +14425,8 @@ create_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new group. "
@@ -14512,8 +14525,8 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a group. "
@@ -14521,8 +14534,8 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a group. "
@@ -14530,8 +14543,8 @@ save_group_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a group. "
@@ -14695,8 +14708,8 @@ create_permission_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a permission. "
@@ -14704,8 +14717,8 @@ create_permission_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a permission. "
@@ -14713,8 +14726,8 @@ create_permission_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a permission. "
@@ -14739,8 +14752,8 @@ create_permission_gmp (gvm_connection_t *connection,
     case 0:                                                                 \
       break;                                                                \
     case 1:                                                                 \
-      cmd_response_data_set_status_code (response_data,                     \
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);   \
+      gsad_command_response_data_set_status_code (                          \
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                     \
       return gsad_http_create_gsad_message (                                \
         credentials,                                                        \
         "An internal error occurred while creating a permission. "          \
@@ -14748,8 +14761,8 @@ create_permission_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",          \
         response_data);                                                     \
     case 2:                                                                 \
-      cmd_response_data_set_status_code (response_data,                     \
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);   \
+      gsad_command_response_data_set_status_code (                          \
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                     \
       return gsad_http_create_gsad_message (                                \
         credentials,                                                        \
         "An internal error occurred while creating a permission. "          \
@@ -14757,8 +14770,8 @@ create_permission_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",    \
         response_data);                                                     \
     default:                                                                \
-      cmd_response_data_set_status_code (response_data,                     \
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);   \
+      gsad_command_response_data_set_status_code (                          \
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                     \
       return gsad_http_create_gsad_message (                                \
         credentials,                                                        \
         "An internal error occurred while creating a permission. "          \
@@ -15242,8 +15255,8 @@ save_permission_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying a permission. "
@@ -15251,8 +15264,8 @@ save_permission_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying a permission. "
@@ -15260,8 +15273,8 @@ save_permission_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying a permission. "
@@ -15322,8 +15335,8 @@ create_port_list_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new port list. "
@@ -15331,8 +15344,8 @@ create_port_list_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new port list. "
@@ -15340,8 +15353,8 @@ create_port_list_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new port list. "
@@ -15405,8 +15418,8 @@ create_port_range_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a Port Range. "
@@ -15414,8 +15427,8 @@ create_port_range_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a Port Range. "
@@ -15423,8 +15436,8 @@ create_port_range_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a Port Range. "
@@ -15545,8 +15558,8 @@ save_port_list_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Port List. "
@@ -15554,8 +15567,8 @@ save_port_list_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Port List. "
@@ -15563,8 +15576,8 @@ save_port_list_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a Port List. "
@@ -15650,8 +15663,8 @@ import_port_list_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a port_list. "
@@ -15659,8 +15672,8 @@ import_port_list_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a port_list. "
@@ -15668,8 +15681,8 @@ import_port_list_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while importing a port_list. "
@@ -15744,8 +15757,8 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new role. "
@@ -15753,8 +15766,8 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new role. "
@@ -15762,8 +15775,8 @@ create_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new role. "
@@ -15916,8 +15929,8 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a role. "
@@ -15925,8 +15938,8 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a role. "
@@ -15934,8 +15947,8 @@ save_role_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a role. "
@@ -15975,8 +15988,8 @@ get_feeds_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (gvm_connection_sendf (connection, "<get_feeds/>") == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the feed list. "
@@ -15987,8 +16000,8 @@ get_feeds_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (read_entity_and_text_c (connection, &entity, &text))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the feed. "
@@ -16039,8 +16052,8 @@ sync_feed (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (gvm_connection_sendf (connection, "<%s/>", sync_cmd) == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
 
       msg = g_strdup_printf (
         "An internal error occurred while synchronizing with %s. "
@@ -16054,8 +16067,8 @@ sync_feed (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
 
       msg = g_strdup_printf (
         "An internal error occurred while synchronizing with %s. "
@@ -16092,8 +16105,8 @@ sync_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (gvm_connection_sendf (connection, "<sync_agents/>") == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
 
       msg = g_strdup_printf (
         "An internal error occurred while synchronizing with agents. "
@@ -16106,8 +16119,8 @@ sync_agents_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
 
       msg = g_strdup_printf (
         "An internal error occurred while synchronizing with agents. "
@@ -16281,8 +16294,8 @@ create_filter_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new alert. "
@@ -16290,8 +16303,8 @@ create_filter_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new alert. "
@@ -16299,8 +16312,8 @@ create_filter_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new alert. "
@@ -16418,8 +16431,8 @@ save_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
     if (ret == -1)
       {
-        cmd_response_data_set_status_code (response_data,
-                                           MHD_HTTP_INTERNAL_SERVER_ERROR);
+        gsad_command_response_data_set_status_code (
+          response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
         return gsad_http_create_gsad_message (
           credentials,
           "An internal error occurred while modifying a filter. "
@@ -16431,8 +16444,8 @@ save_filter_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     entity = NULL;
     if (read_entity_c (connection, &entity))
       {
-        cmd_response_data_set_status_code (response_data,
-                                           MHD_HTTP_INTERNAL_SERVER_ERROR);
+        gsad_command_response_data_set_status_code (
+          response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
         return gsad_http_create_gsad_message (
           credentials,
           "An internal error occurred while modifying a filter. "
@@ -16536,8 +16549,8 @@ save_schedule_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a schedule. "
@@ -16545,8 +16558,8 @@ save_schedule_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a schedule. "
@@ -16554,8 +16567,8 @@ save_schedule_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a schedule. "
@@ -16625,24 +16638,24 @@ get_user (gvm_connection_t *connection, gsad_credentials_t *credentials,
         case 0:
           break;
         case 1:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred getting the auth list. "
@@ -16824,8 +16837,8 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new user. "
@@ -16833,8 +16846,8 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new user. "
@@ -16842,8 +16855,8 @@ create_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new user. "
@@ -16907,24 +16920,24 @@ auth_settings_gmp (gvm_connection_t *connection,
         case 0:
           break;
         case 1:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred getting the auth list. "
@@ -17125,8 +17138,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         }
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a user. "
@@ -17134,8 +17147,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a user. "
@@ -17143,8 +17156,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a user. "
@@ -17159,7 +17172,8 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       free_entity (entity);
 
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_UNAUTHORIZED);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_UNAUTHORIZED);
       return gsad_http_create_gsad_message (
         credentials, "Authentication method changed. Please login with ",
         response_data);
@@ -17394,8 +17408,8 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving the auth settings. "
@@ -17403,8 +17417,8 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving the auth settings. "
@@ -17412,8 +17426,8 @@ save_auth_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving the auth settings. "
@@ -17472,8 +17486,8 @@ get_settings_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       g_free (command);
 
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the settings. "
@@ -17486,8 +17500,8 @@ get_settings_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       g_free (command);
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the settings. "
@@ -17571,8 +17585,8 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving settings. "
@@ -17581,8 +17595,8 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         response_data);
     case 2:
 
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving settings. "
@@ -17591,8 +17605,8 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         response_data);
     default:
 
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving settings. "
@@ -17620,8 +17634,8 @@ get_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
                                 setting_id))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the "
@@ -17634,8 +17648,8 @@ get_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (read_string_c (connection, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the "
@@ -17673,7 +17687,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (name == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the wizard. "
@@ -17695,8 +17710,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the wizard. "
@@ -17707,8 +17722,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (read_string_c (connection, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the"
@@ -17726,8 +17741,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
       == -1)
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the wizard. "
@@ -17738,8 +17753,8 @@ wizard (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (read_string_c (connection, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while the wizard. "
@@ -17804,7 +17819,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
   name = params_value (params, "get_name");
   if (name == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while trying to start a wizard. "
@@ -17844,8 +17860,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while running a wizard. "
@@ -17853,8 +17869,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while running a wizard. "
@@ -17862,8 +17878,8 @@ wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while running a wizard. "
@@ -17919,7 +17935,8 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   type = params_value (params, "resource_type");
   if (type == NULL)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting resources. "
@@ -17964,7 +17981,7 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
             {
               g_free (command);
               g_free (extra_attribs);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -17979,7 +17996,7 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
           if (read_entity_c (connection, &entity))
             {
               g_free (extra_attribs);
-              cmd_response_data_set_status_code (
+              gsad_command_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_http_create_gsad_message (
                 credentials,
@@ -18005,7 +18022,8 @@ bulk_delete_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     {
       gchar *html, *msg;
 
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
 
       msg = g_strdup_printf (
         "An error occurred while deleting one or more resources. "
@@ -18124,8 +18142,8 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new host. "
@@ -18133,8 +18151,8 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new host. "
@@ -18142,8 +18160,8 @@ create_host_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new host. "
@@ -18185,7 +18203,8 @@ get_asset (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (params_value (params, "asset_name") && params_value (params, "asset_id"))
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting an asset. "
@@ -18295,8 +18314,8 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating an asset. "
@@ -18304,8 +18323,8 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating an asset. "
@@ -18313,8 +18332,8 @@ create_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating an asset. "
@@ -18353,7 +18372,8 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     resource_id = g_strdup (params_value (params, "report_id"));
   else
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting an asset. "
@@ -18382,8 +18402,8 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
       == -1)
     {
       g_free (resource_id);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting an asset. "
@@ -18397,8 +18417,8 @@ delete_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting an asset. "
@@ -18491,8 +18511,8 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an asset. "
@@ -18500,8 +18520,8 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an asset. "
@@ -18509,8 +18529,8 @@ save_asset_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an asset. "
@@ -18601,16 +18621,16 @@ create_ticket_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a ticket. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a ticket. "
@@ -18618,8 +18638,8 @@ create_ticket_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a ticket. "
@@ -18681,16 +18701,16 @@ save_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a ticket. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a ticket. "
@@ -18698,8 +18718,8 @@ save_ticket_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a ticket. "
@@ -18755,8 +18775,8 @@ get_timezones_gmp (gvm_connection_t *connection,
   /* Get timezones list */
   if (gvm_connection_sendf (connection, "<get_timezones/>"))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the timezones list. "
@@ -18770,8 +18790,8 @@ get_timezones_gmp (gvm_connection_t *connection,
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the timezones list. "
@@ -18910,16 +18930,16 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a TLS certificate. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a TLS certificate. "
@@ -18927,8 +18947,8 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a TLS certificate. "
@@ -18995,16 +19015,16 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a TLS certificate. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a TLS certificate. "
@@ -19012,8 +19032,8 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving a TLS certificate. "
@@ -19123,8 +19143,8 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_free (file_base64);
       return gsad_http_create_gsad_message (
         credentials,
@@ -19133,8 +19153,8 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_free (file_base64);
       return gsad_http_create_gsad_message (
         credentials,
@@ -19143,8 +19163,8 @@ save_license_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_free (file_base64);
       return gsad_http_create_gsad_message (
         credentials,
@@ -19201,8 +19221,8 @@ change_password_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while changing the password. "
@@ -19210,8 +19230,8 @@ change_password_gmp (gvm_connection_t *connection,
         "Diagnostics: Manager closed connection during authenticate.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "You tried to change your password, but the old"
@@ -19219,8 +19239,8 @@ change_password_gmp (gvm_connection_t *connection,
         " Please enter the correct old password to proceed.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while changing the password. "
@@ -19240,8 +19260,8 @@ change_password_gmp (gvm_connection_t *connection,
       == -1)
     {
       g_free (passwd_64);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while changing the password. "
@@ -19252,8 +19272,8 @@ change_password_gmp (gvm_connection_t *connection,
 
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while changing the password. "
@@ -19345,7 +19365,8 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
 
   if (!id || strlen (id) == 0)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials, "The 'agent_installer_id' parameter is required.",
         response_data);
@@ -19356,8 +19377,8 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
         connection, "<get_agent_installer_file agent_installer_id=\"%s\"/>", id)
       == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials, "Failed to send GMP command to retrieve installer.",
         response_data);
@@ -19366,8 +19387,8 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
   // Parse response
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials, "Failed to receive installer file response.",
         response_data);
@@ -19390,8 +19411,8 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
   if (!file_entity || !entity_text (file_entity))
     {
       free_entity (entity);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials, "No agent installer content was returned.", response_data);
     }
@@ -19549,7 +19570,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (!agent_ids)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials, "The 'agent_ids' parameter is required.", response_data);
     }
@@ -19661,8 +19683,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent list. "
@@ -19670,8 +19692,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent list. "
@@ -19679,8 +19701,8 @@ modify_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agents list. "
@@ -19748,7 +19770,8 @@ modify_agent_control_scan_config_gmp (
   agent_control_id = params_value (params, "agent_control_id");
   if (!agent_control_id)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials, "The 'agent_control_id' parameter is required.",
         response_data);
@@ -19819,8 +19842,8 @@ modify_agent_control_scan_config_gmp (
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying the agent control "
@@ -19828,8 +19851,8 @@ modify_agent_control_scan_config_gmp (
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying the agent control "
@@ -19838,8 +19861,8 @@ modify_agent_control_scan_config_gmp (
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying the agent control "
@@ -19881,7 +19904,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (!agent_ids)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials, "The 'agent_ids' parameter is required.", response_data);
     }
@@ -19913,8 +19937,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting an agent list. "
@@ -19922,8 +19946,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting an agent list. "
@@ -19931,8 +19955,8 @@ delete_agent_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while deleting an agents list. "
@@ -20028,7 +20052,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
 
   if (!agent_ids && !copy)
     {
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_BAD_REQUEST);
       return gsad_http_create_gsad_message (
         credentials, "The 'agent_ids' parameter is required.", response_data);
     }
@@ -20060,8 +20085,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new agent group. "
@@ -20069,8 +20094,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new agent group. "
@@ -20078,8 +20103,8 @@ create_agent_group_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new agent group. "
@@ -20163,8 +20188,8 @@ save_agent_group_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent group. "
@@ -20172,8 +20197,8 @@ save_agent_group_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent group. "
@@ -20181,8 +20206,8 @@ save_agent_group_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while saving an agent group. "
@@ -20424,8 +20449,8 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
     case 0:
       break;
     case 1:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new OCI image target. "
@@ -20433,8 +20458,8 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
     case 2:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new OCI image target. "
@@ -20442,8 +20467,8 @@ create_oci_image_target_gmp (gvm_connection_t *connection,
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while creating a new OCI image target. "
@@ -20534,8 +20559,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
         case 0:
           break;
         case 1:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving an OCI image target. "
@@ -20543,8 +20568,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving an OCI image target. "
@@ -20552,8 +20577,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred while saving an OCI image target. "
@@ -20638,8 +20663,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
 
   if (ret == -1)
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying an OCI image target. "
@@ -20651,8 +20676,8 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
   entity = NULL;
   if (read_entity_c (connection, &entity))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while modifying an OCI image target. "
@@ -20697,8 +20722,8 @@ get_capabilities_gmp (gvm_connection_t *connection,
   if (gvm_connection_sendf (connection,
                             "<help format=\"XML\" type=\"brief\"/>"))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the user credentials. "
@@ -20713,8 +20738,8 @@ get_capabilities_gmp (gvm_connection_t *connection,
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the user credentials. "
@@ -20755,8 +20780,8 @@ get_features_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   /* Get features list */
   if (gvm_connection_sendf (connection, "<get_features/>"))
     {
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the features list. "
@@ -20771,8 +20796,8 @@ get_features_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   if (read_entity_and_string_c (connection, &entity, &xml))
     {
       g_string_free (xml, TRUE);
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred while getting the feature list. "

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -1252,7 +1252,7 @@ export_resource (gvm_connection_t *connection, const char *type,
 
   gsad_command_response_data_set_content_type (response_data,
                                                GSAD_CONTENT_TYPE_APP_XML);
-  cmd_response_data_set_content_disposition (
+  gsad_command_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=\"%s.xml\"", file_name));
   gsad_command_response_data_set_content_length (response_data,
@@ -1431,7 +1431,7 @@ export_many (gvm_connection_t *connection, const char *type,
 
   gsad_command_response_data_set_content_type (response_data,
                                                GSAD_CONTENT_TYPE_APP_XML);
-  cmd_response_data_set_content_disposition (
+  gsad_command_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=\"%s.xml\"", file_name));
   gsad_command_response_data_set_content_length (response_data,
@@ -4307,8 +4307,8 @@ download_credential_gmp (gvm_connection_t *connection,
                      (strcmp (format, "key") == 0 ? "pub" : format));
   content_type_from_format_string (&content_type, format);
 
-  cmd_response_data_set_content_disposition (response_data,
-                                             content_disposition);
+  gsad_command_response_data_set_content_disposition (response_data,
+                                                      content_disposition);
   gsad_command_response_data_set_content_type (response_data, content_type);
 
   free_entity (entity);
@@ -9056,7 +9056,7 @@ export_preference_file_gmp (gvm_connection_t *connection,
       char *content = strdup (entity_text (value_entity));
       gsad_command_response_data_set_content_type (
         response_data, GSAD_CONTENT_TYPE_OCTET_STREAM);
-      cmd_response_data_set_content_disposition (
+      gsad_command_response_data_set_content_disposition (
         response_data,
         g_strdup_printf ("attachment; filename=\"pref_file.bin\""));
       gsad_command_response_data_set_content_length (response_data,
@@ -9351,7 +9351,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
               gsad_command_response_data_set_content_type_string (
                 response_data, g_strdup (requested_content_type));
-              cmd_response_data_set_content_disposition (
+              gsad_command_response_data_set_content_disposition (
                 response_data,
                 g_strdup_printf ("attachment; filename=\"%s.%s\"", file_name,
                                  extension));
@@ -9464,7 +9464,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
                   gsad_command_response_data_set_content_type_string (
                     response_data, g_strdup (requested_content_type));
-                  cmd_response_data_set_content_disposition (
+                  gsad_command_response_data_set_content_disposition (
                     response_data,
                     g_strdup_printf ("attachment; filename=\"%s.%s\"",
                                      file_name, extension));
@@ -19458,7 +19458,7 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
         response_data, g_strdup (content_type));
     }
 
-  cmd_response_data_set_content_disposition (
+  gsad_command_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=%s.%s", name, format));
   gsad_command_response_data_set_content_length (response_data, content_length);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -1246,7 +1246,8 @@ export_resource (gvm_connection_t *connection, const char *type,
   if (file_name == NULL)
     file_name = g_strdup_printf ("%s-%s", type, resource_id);
 
-  cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_APP_XML);
   cmd_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=\"%s.xml\"", file_name));
@@ -1423,7 +1424,8 @@ export_many (gvm_connection_t *connection, const char *type,
 
   g_free (type_many);
 
-  cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_APP_XML);
   cmd_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=\"%s.xml\"", file_name));
@@ -4298,7 +4300,7 @@ download_credential_gmp (gvm_connection_t *connection,
 
   cmd_response_data_set_content_disposition (response_data,
                                              content_disposition);
-  cmd_response_data_set_content_type (response_data, content_type);
+  gsad_command_response_data_set_content_type (response_data, content_type);
 
   free_entity (entity);
   g_free (login);
@@ -9042,8 +9044,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
       && (value_entity = entity_child (preference_entity, "value")))
     {
       char *content = strdup (entity_text (value_entity));
-      cmd_response_data_set_content_type (response_data,
-                                          GSAD_CONTENT_TYPE_OCTET_STREAM);
+      gsad_command_response_data_set_content_type (
+        response_data, GSAD_CONTENT_TYPE_OCTET_STREAM);
       cmd_response_data_set_content_disposition (
         response_data,
         g_strdup_printf ("attachment; filename=\"pref_file.bin\""));
@@ -9336,7 +9338,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
               if (file_name == NULL)
                 file_name = g_strdup_printf ("%s-%s", "report", report_id);
 
-              cmd_response_data_set_content_type_string (
+              gsad_command_response_data_set_content_type_string (
                 response_data, g_strdup (requested_content_type));
               cmd_response_data_set_content_disposition (
                 response_data,
@@ -9449,7 +9451,7 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
                   if (file_name == NULL)
                     file_name = g_strdup_printf ("%s-%s", "report", id);
 
-                  cmd_response_data_set_content_type_string (
+                  gsad_command_response_data_set_content_type_string (
                     response_data, g_strdup (requested_content_type));
                   cmd_response_data_set_content_disposition (
                     response_data,
@@ -11844,12 +11846,12 @@ get_system_report_gmp_from_url (gvm_connection_t *connection,
               if (strcmp (entity_attribute (report_entity, "format"), "png")
                   == 0)
                 {
-                  cmd_response_data_set_content_type (
+                  gsad_command_response_data_set_content_type (
                     response_data, GSAD_CONTENT_TYPE_IMAGE_PNG);
                 }
               else
                 {
-                  cmd_response_data_set_content_type (
+                  gsad_command_response_data_set_content_type (
                     response_data, GSAD_CONTENT_TYPE_TEXT_PLAIN);
                 }
                 //*content_disposition = g_strdup_printf ("attachment;
@@ -17556,7 +17558,8 @@ save_setting_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   xml_string_append (xml, "</modify_setting>");
 
-  cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_APP_XML);
 
   ret = gmp (connection, credentials, NULL, &entity, response_data, xml->str);
 
@@ -19266,7 +19269,8 @@ change_password_gmp (gvm_connection_t *connection,
       gsad_session_replace_user_if_exists (user);
     }
 
-  cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_APP_XML);
   html = response_from_entity (connection, credentials, params, entity,
                                "Change Password", response_data);
   return html;
@@ -19416,13 +19420,13 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
 
   if (!content_type || strlen (content_type) == 0)
     {
-      cmd_response_data_set_content_type (response_data,
-                                          GSAD_CONTENT_TYPE_OCTET_STREAM);
+      gsad_command_response_data_set_content_type (
+        response_data, GSAD_CONTENT_TYPE_OCTET_STREAM);
     }
   else
     {
-      cmd_response_data_set_content_type_string (response_data,
-                                                 g_strdup (content_type));
+      gsad_command_response_data_set_content_type_string (
+        response_data, g_strdup (content_type));
     }
 
   cmd_response_data_set_content_disposition (

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -1255,7 +1255,8 @@ export_resource (gvm_connection_t *connection, const char *type,
   cmd_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=\"%s.xml\"", file_name));
-  cmd_response_data_set_content_length (response_data, strlen (content));
+  gsad_command_response_data_set_content_length (response_data,
+                                                 strlen (content));
 
   free_entity (entity);
   g_free (file_name);
@@ -1433,7 +1434,8 @@ export_many (gvm_connection_t *connection, const char *type,
   cmd_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=\"%s.xml\"", file_name));
-  cmd_response_data_set_content_length (response_data, strlen (content));
+  gsad_command_response_data_set_content_length (response_data,
+                                                 strlen (content));
 
   free_entity (entity);
   g_free (file_name);
@@ -4223,7 +4225,7 @@ download_credential_gmp (gvm_connection_t *connection,
               len = 0;
             }
 
-          cmd_response_data_set_content_length (response_data, len);
+          gsad_command_response_data_set_content_length (response_data, len);
         }
       else
         {
@@ -4272,7 +4274,8 @@ download_credential_gmp (gvm_connection_t *connection,
           else
             login = NULL;
 
-          cmd_response_data_set_content_length (response_data, strlen (data));
+          gsad_command_response_data_set_content_length (response_data,
+                                                         strlen (data));
         }
       else
         {
@@ -9056,7 +9059,8 @@ export_preference_file_gmp (gvm_connection_t *connection,
       cmd_response_data_set_content_disposition (
         response_data,
         g_strdup_printf ("attachment; filename=\"pref_file.bin\""));
-      cmd_response_data_set_content_length (response_data, strlen (content));
+      gsad_command_response_data_set_content_length (response_data,
+                                                     strlen (content));
       free_entity (entity);
       g_string_free (xml, TRUE);
       return content;
@@ -9470,7 +9474,8 @@ get_report (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
               free_entity (entity);
 
-              cmd_response_data_set_content_length (response_data, report_len);
+              gsad_command_response_data_set_content_length (response_data,
+                                                             report_len);
               return report_decoded;
             }
           else
@@ -10178,7 +10183,7 @@ download_ssl_cert (gvm_connection_t *connection,
                           "%s\n-----END CERTIFICATE-----\n",
                           unescaped);
 
-  cmd_response_data_set_content_length (response_data, strlen (cert));
+  gsad_command_response_data_set_content_length (response_data, strlen (cert));
 
   g_free (unescaped);
   return cert;
@@ -10213,7 +10218,8 @@ download_ca_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
     }
   /* The Base64 comes URI escaped as it may contain special characters. */
   unescaped = g_uri_unescape_string (ca_pub, NULL);
-  cmd_response_data_set_content_length (response_data, strlen (unescaped));
+  gsad_command_response_data_set_content_length (response_data,
+                                                 strlen (unescaped));
   return unescaped;
 }
 
@@ -10247,7 +10253,8 @@ download_key_pub (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   /* The Base64 comes URI escaped as it may contain special characters. */
   unescaped = g_uri_unescape_string (key_pub, NULL);
-  cmd_response_data_set_content_length (response_data, strlen (unescaped));
+  gsad_command_response_data_set_content_length (response_data,
+                                                 strlen (unescaped));
   return unescaped;
 }
 
@@ -11874,7 +11881,8 @@ get_system_report_gmp_from_url (gvm_connection_t *connection,
 #endif
             }
 
-          cmd_response_data_set_content_length (response_data, content_length);
+          gsad_command_response_data_set_content_length (response_data,
+                                                         content_length);
           free_entity (entity);
           return content;
         }
@@ -19453,7 +19461,7 @@ get_agent_installer_file_gmp (gvm_connection_t *connection,
   cmd_response_data_set_content_disposition (
     response_data,
     g_strdup_printf ("attachment; filename=%s.%s", name, format));
-  cmd_response_data_set_content_length (response_data, content_length);
+  gsad_command_response_data_set_content_length (response_data, content_length);
 
   free_entity (entity);
   return content_decoded;

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -11,7 +11,7 @@
 #ifndef _GSAD_GMP_H
 #define _GSAD_GMP_H
 
-#include "gsad_cmd.h"          /* for cmd_response_data_t */
+#include "gsad_cmd.h"          /* for gsad_command_response_data_t */
 #include "gsad_content_type.h" /* for content_type */
 #include "gsad_http.h"         /* for gsad_http_connection_t */
 #include "gsad_user.h"         /* for credentials_t */
@@ -21,922 +21,924 @@
 
 char *
 clone_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-           cmd_response_data_t *);
+           gsad_command_response_data_t *);
 
 char *
 create_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 create_import_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 create_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 save_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 save_import_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 resume_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 start_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 stop_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 move_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 
 char *
 get_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 get_tasks_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 get_tasks_chart_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 export_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_tasks_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 delete_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 get_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_report_errors_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 get_report_hosts_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 get_report_ports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 get_report_tls_certificates_gmp (gvm_connection_t *, gsad_credentials_t *,
-                                 params_t *, cmd_response_data_t *);
+                                 params_t *, gsad_command_response_data_t *);
 char *
 get_reports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 report_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 download_ssl_cert (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 download_ca_pub (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 download_key_pub (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 export_result_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_results_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_result_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_results_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 new_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 create_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 delete_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 test_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 edit_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 save_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_alerts_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 export_alert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 export_alerts_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 char *
 download_credential_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                         cmd_response_data_t *);
+                         gsad_command_response_data_t *);
 char *
 export_credential_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 export_credentials_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 get_credential_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_credentials_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 
 char *
 get_credential_stores_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 char *
 modify_credential_store_gmp (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *, cmd_response_data_t *);
+                             params_t *, gsad_command_response_data_t *);
 char *
 verify_credential_store_gmp (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *, cmd_response_data_t *);
+                             params_t *, gsad_command_response_data_t *);
 char *
 create_credential_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 delete_credential_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 save_credential_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 
 char *
 get_aggregate_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 char *
 create_scanner_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_scanner_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 get_scanners_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 save_scanner_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 delete_scanner_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 export_scanner_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 export_scanners_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 verify_scanner_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 
 char *
 create_schedule_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 delete_schedule_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 get_schedule_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 get_schedules_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 save_schedule_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_schedule_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 export_schedules_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 create_tag_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 create_tags_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_tag_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 export_tags_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_tag_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_tag_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-             cmd_response_data_t *);
+             gsad_command_response_data_t *);
 char *
 get_tags_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 save_tag_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 toggle_tag_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 
 char *
 get_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_targets_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_targets_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 export_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 create_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 delete_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 save_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 get_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_configs_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 save_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 edit_config_family_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 edit_config_family_all_gmp (gvm_connection_t *, gsad_credentials_t *,
-                            params_t *, cmd_response_data_t *);
+                            params_t *, gsad_command_response_data_t *);
 char *
 get_config_family_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 save_config_family_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 get_config_nvt_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 save_config_nvt_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 create_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 import_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 delete_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_configs_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 
 char *
 export_preference_file_gmp (gvm_connection_t *, gsad_credentials_t *,
-                            params_t *, cmd_response_data_t *);
+                            params_t *, gsad_command_response_data_t *);
 char *
 export_report_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 export_report_configs_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 char *
 export_report_format_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 export_report_formats_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 
 char *
 create_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 delete_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 export_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 export_groups_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 get_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 get_groups_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 save_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 
 char *
 get_notes_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 get_note_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 create_note_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_note_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 save_note_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 export_note_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_notes_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 get_nvt_families_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 create_permission_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 create_permissions_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 delete_permission_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 export_permission_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 export_permissions_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 get_permission_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_permissions_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 save_permission_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 create_port_list_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 create_port_range_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 get_port_list_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 save_port_list_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_port_lists_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 delete_port_list_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 delete_port_range_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 export_port_list_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 export_port_lists_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 import_port_list_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 create_role_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_role_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_role_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_roles_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 get_role_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 get_roles_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 save_role_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 
 char *
 get_overrides_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 get_override_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 create_override_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 delete_override_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 save_override_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_override_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 export_overrides_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 get_slave_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 get_slaves_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 create_slave_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 save_slave_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 delete_slave_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 export_slave_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 export_slaves_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 char *
 get_system_reports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 get_system_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 get_system_report_gmp_from_url (gvm_connection_t *, gsad_credentials_t *,
                                 const char *, params_t *,
-                                cmd_response_data_t *);
+                                gsad_command_response_data_t *);
 
 char *
 get_report_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 get_report_configs_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 create_report_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 delete_report_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 save_report_config_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 
 char *
 get_report_format_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 get_report_formats_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 char *
 delete_report_format_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 import_report_format_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 save_report_format_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 
 char *
 get_resource_names_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 
 char *
 get_features_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 get_feeds_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 
 char *
 sync_agents_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 sync_feed_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 sync_scap_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 sync_cert_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 
 char *
 create_filter_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 delete_filter_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_filter_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 export_filters_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_filter_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_filters_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 save_filter_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 create_user_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_user_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_user_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 export_users_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 get_user_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 get_users_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 save_user_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 get_vulns_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 save_auth_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 
 char *
 bulk_delete_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 bulk_export_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 run_wizard_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 wizard_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-            cmd_response_data_t *);
+            gsad_command_response_data_t *);
 char *
 wizard_get_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 
 char *
 cvss_calculator (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 get_trash_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 get_trash_alerts_gmp (gvm_connection_t *, gsad_credentials_t *,
-                      params_t *params, cmd_response_data_t *);
+                      params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_configs_gmp (gvm_connection_t *, gsad_credentials_t *,
-                       params_t *params, cmd_response_data_t *);
+                       params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_credentials_gmp (gvm_connection_t *, gsad_credentials_t *,
-                           params_t *params, cmd_response_data_t *);
+                           params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_filters_gmp (gvm_connection_t *, gsad_credentials_t *,
-                       params_t *params, cmd_response_data_t *);
+                       params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_groups_gmp (gvm_connection_t *, gsad_credentials_t *,
-                      params_t *params, cmd_response_data_t *);
+                      params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_notes_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 get_trash_overrides_gmp (gvm_connection_t *, gsad_credentials_t *,
-                         params_t *params, cmd_response_data_t *);
+                         params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_permissions_gmp (gvm_connection_t *, gsad_credentials_t *,
-                           params_t *params, cmd_response_data_t *);
+                           params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_port_lists_gmp (gvm_connection_t *, gsad_credentials_t *,
-                          params_t *params, cmd_response_data_t *);
+                          params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_report_configs_gmp (gvm_connection_t *, gsad_credentials_t *,
-                              params_t *params, cmd_response_data_t *);
+                              params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_report_formats_gmp (gvm_connection_t *, gsad_credentials_t *,
-                              params_t *params, cmd_response_data_t *);
+                              params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_roles_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 get_trash_scanners_gmp (gvm_connection_t *, gsad_credentials_t *,
-                        params_t *params, cmd_response_data_t *);
+                        params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_schedules_gmp (gvm_connection_t *, gsad_credentials_t *,
-                         params_t *params, cmd_response_data_t *);
+                         params_t *params, gsad_command_response_data_t *);
 char *
 get_trash_tags_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 char *
 get_trash_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
-                       params_t *params, cmd_response_data_t *);
+                       params_t *params, gsad_command_response_data_t *);
 
 char *
 get_trash_oci_image_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
-                                 params_t *params, cmd_response_data_t *);
+                                 params_t *params,
+                                 gsad_command_response_data_t *);
 
 char *
 get_trash_tasks_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 char *
 get_trash_tickets_gmp (gvm_connection_t *, gsad_credentials_t *,
-                       params_t *params, cmd_response_data_t *);
+                       params_t *params, gsad_command_response_data_t *);
 
 char *
 get_trash_agent_group_gmp (gvm_connection_t *connection,
                            gsad_credentials_t *credentials, params_t *params,
-                           cmd_response_data_t *response_data);
+                           gsad_command_response_data_t *response_data);
 
 char *
 get_trash_oci_image_targets (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *params, cmd_response_data_t *);
+                             params_t *params, gsad_command_response_data_t *);
 
 char *
 restore_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-             cmd_response_data_t *);
+             gsad_command_response_data_t *);
 char *
 delete_from_trash_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                       cmd_response_data_t *);
+                       gsad_command_response_data_t *);
 char *
 empty_trashcan_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                    cmd_response_data_t *);
+                    gsad_command_response_data_t *);
 
 char *
 get_settings_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 save_my_settings_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      const gchar *, cmd_response_data_t *);
+                      const gchar *, gsad_command_response_data_t *);
 char *
 get_setting_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 save_setting_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 auth_settings_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 char *
 get_info_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-              cmd_response_data_t *);
+              gsad_command_response_data_t *);
 char *
 get_info (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-          cmd_response_data_t *);
+          gsad_command_response_data_t *);
 
 char *
 create_asset_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 create_host_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_asset_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 save_asset_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_assets_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 get_asset_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 char *
 export_asset_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 export_assets_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 get_assets_chart_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 get_tickets_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 get_ticket_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 char *
 create_ticket_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 save_ticket_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 char *
 delete_ticket_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 char *
 get_timezones_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 
 char *
 get_tls_certificates_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 get_tls_certificate_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                         cmd_response_data_t *);
+                         gsad_command_response_data_t *);
 char *
 create_tls_certificate_gmp (gvm_connection_t *, gsad_credentials_t *,
-                            params_t *, cmd_response_data_t *);
+                            params_t *, gsad_command_response_data_t *);
 char *
 save_tls_certificate_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 delete_tls_certificate_gmp (gvm_connection_t *, gsad_credentials_t *,
-                            params_t *, cmd_response_data_t *);
+                            params_t *, gsad_command_response_data_t *);
 
 char *
 get_license_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 cmd_response_data_t *);
+                 gsad_command_response_data_t *);
 
 char *
 save_license_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 get_capabilities_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 get_agent_installers_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 
 char *
 get_agent_installer_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                         cmd_response_data_t *);
+                         gsad_command_response_data_t *);
 
 char *
 get_agent_installer_file_gmp (gvm_connection_t *, gsad_credentials_t *,
-                              params_t *, cmd_response_data_t *);
+                              params_t *, gsad_command_response_data_t *);
 
 char *
 get_agent_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-               cmd_response_data_t *);
+               gsad_command_response_data_t *);
 
 char *
 get_agents_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                cmd_response_data_t *);
+                gsad_command_response_data_t *);
 
 char *
 modify_agent_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 
 char *
 modify_agent_control_scan_config_gmp (gvm_connection_t *, gsad_credentials_t *,
-                                      params_t *, cmd_response_data_t *);
+                                      params_t *,
+                                      gsad_command_response_data_t *);
 
 char *
 delete_agent_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                  cmd_response_data_t *);
+                  gsad_command_response_data_t *);
 char *
 get_agent_groups_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 get_agent_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 
 char *
 create_agent_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 
 char *
 save_agent_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      cmd_response_data_t *);
+                      gsad_command_response_data_t *);
 
 char *
 delete_agent_group_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                        cmd_response_data_t *);
+                        gsad_command_response_data_t *);
 
 char *
 create_agent_group_task_gmp (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *, cmd_response_data_t *);
+                             params_t *, gsad_command_response_data_t *);
 
 char *
 save_agent_group_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 
 char *
 get_oci_image_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                          cmd_response_data_t *);
+                          gsad_command_response_data_t *);
 char *
 get_oci_image_targets_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 char *
 export_oci_image_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
-                              params_t *, cmd_response_data_t *);
+                              params_t *, gsad_command_response_data_t *);
 char *
 export_oci_image_target_gmp (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *, cmd_response_data_t *);
+                             params_t *, gsad_command_response_data_t *);
 char *
 create_oci_image_target_gmp (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *, cmd_response_data_t *);
+                             params_t *, gsad_command_response_data_t *);
 char *
 delete_oci_image_target_gmp (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *, cmd_response_data_t *);
+                             params_t *, gsad_command_response_data_t *);
 char *
 save_oci_image_target_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 
 char *
 create_oci_image_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 
 char *
 save_oci_image_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                         cmd_response_data_t *);
+                         gsad_command_response_data_t *);
 
 char *
 renew_session_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                   cmd_response_data_t *);
+                   gsad_command_response_data_t *);
 char *
 ping_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-          cmd_response_data_t *);
+          gsad_command_response_data_t *);
 
 char *
 change_password_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                     cmd_response_data_t *);
+                     gsad_command_response_data_t *);
 
 int
 login (gsad_http_connection_t *con, params_t *params,
-       cmd_response_data_t *response_data, const char *client_address);
+       gsad_command_response_data_t *response_data, const char *client_address);
 
 #endif /* not _GSAD_GMP_H */

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -11,10 +11,10 @@
 #ifndef _GSAD_GMP_H
 #define _GSAD_GMP_H
 
-#include "gsad_cmd.h"          /* for gsad_command_response_data_t */
-#include "gsad_content_type.h" /* for content_type */
-#include "gsad_http.h"         /* for gsad_http_connection_t */
-#include "gsad_user.h"         /* for credentials_t */
+#include "gsad_command_response_data.h" /* for gsad_command_response_data_t */
+#include "gsad_content_type.h"          /* for content_type */
+#include "gsad_http.h"                  /* for gsad_http_connection_t */
+#include "gsad_user.h"                  /* for credentials_t */
 
 #include <glib.h>                 /* for gboolean */
 #include <gvm/util/serverutils.h> /* for gvm_connection_t */

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -494,7 +494,7 @@ gsad_http_send_response (gsad_http_connection_t *connection,
                                content_disposition);
     }
 
-  if (cmd_response_data_is_allow_caching (response_data) == FALSE)
+  if (gsad_command_response_data_is_allow_caching (response_data) == FALSE)
     gsad_http_add_forbid_caching_headers (response);
   gsad_http_add_security_headers (response);
   gsad_http_add_cors_headers (response);

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -499,7 +499,7 @@ gsad_http_send_response (gsad_http_connection_t *connection,
   gsad_http_add_security_headers (response);
   gsad_http_add_cors_headers (response);
 
-  status_code = cmd_response_data_get_status_code (response_data);
+  status_code = gsad_command_response_data_get_status_code (response_data);
 
   gsad_command_response_data_free (response_data);
 
@@ -562,7 +562,8 @@ gsad_http_create_not_found_response (
   gsad_http_response_t *response;
   int len;
 
-  cmd_response_data_set_status_code (response_data, MHD_HTTP_NOT_FOUND);
+  gsad_command_response_data_set_status_code (response_data,
+                                              MHD_HTTP_NOT_FOUND);
 
   gchar *msg =
     "<!DOCTYPE html>"
@@ -644,7 +645,7 @@ gsad_http_send_reauthentication (gsad_http_connection_t *connection,
 
   gsad_command_response_data_t *response_data =
     gsad_command_response_data_new ();
-  cmd_response_data_set_status_code (response_data, http_status_code);
+  gsad_command_response_data_set_status_code (response_data, http_status_code);
 
   gchar *xml = gsad_http_create_gsad_message (NULL, msg, response_data);
 
@@ -693,7 +694,7 @@ gsad_http_create_file_content_response (
   FILE *file;
   struct stat buf;
 
-  cmd_response_data_set_status_code (response_data, MHD_HTTP_OK);
+  gsad_command_response_data_set_status_code (response_data, MHD_HTTP_OK);
 
   if (!str_equal (path, "index.html") && !gvm_file_exists (path))
     {
@@ -702,7 +703,8 @@ gsad_http_create_file_content_response (
       g_debug ("File %s not found. Return index.html", path);
 
       path = "index.html";
-      cmd_response_data_set_status_code (response_data, MHD_HTTP_NOT_FOUND);
+      gsad_command_response_data_set_status_code (response_data,
+                                                  MHD_HTTP_NOT_FOUND);
     }
 
   file = fopen (path, "r"); /* this file is just read and sent */

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -467,7 +467,7 @@ gsad_http_send_response (gsad_http_connection_t *connection,
 
   if (gsad_http_attach_remove_sid (response, sid) == MHD_NO)
     {
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
       MHD_destroy_response (response);
       return MHD_NO;
     }
@@ -501,7 +501,7 @@ gsad_http_send_response (gsad_http_connection_t *connection,
 
   status_code = cmd_response_data_get_status_code (response_data);
 
-  cmd_response_data_free (response_data);
+  gsad_command_response_data_free (response_data);
 
   ret = MHD_queue_response (connection, status_code, response);
   if (ret == MHD_NO)
@@ -642,7 +642,8 @@ gsad_http_send_reauthentication (gsad_http_connection_t *connection,
       msg = "";
     }
 
-  gsad_command_response_data_t *response_data = cmd_response_data_new ();
+  gsad_command_response_data_t *response_data =
+    gsad_command_response_data_new ();
   cmd_response_data_set_status_code (response_data, http_status_code);
 
   gchar *xml = gsad_http_create_gsad_message (NULL, msg, response_data);

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -472,13 +472,13 @@ gsad_http_send_response (gsad_http_connection_t *connection,
       return MHD_NO;
     }
 
-  content_type = cmd_response_data_get_content_type (response_data);
+  content_type = gsad_command_response_data_get_content_type (response_data);
 
   if (content_type == GSAD_CONTENT_TYPE_STRING)
     {
       MHD_add_response_header (
         response, MHD_HTTP_HEADER_CONTENT_TYPE,
-        cmd_response_data_get_content_type_string (response_data));
+        gsad_command_response_data_get_content_type_string (response_data));
     }
   else
     {
@@ -580,8 +580,8 @@ gsad_http_create_not_found_response (
     "</body>"
     "</html>";
 
-  cmd_response_data_set_content_type (response_data,
-                                      GSAD_CONTENT_TYPE_TEXT_HTML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_TEXT_HTML);
 
   cmd_response_data_set_content_length (response_data, strlen (msg));
 
@@ -714,8 +714,8 @@ gsad_http_create_file_content_response (
     }
 
   /* Guess content type. */
-  cmd_response_data_set_content_type (response_data,
-                                      gsad_http_guess_content_type (path));
+  gsad_command_response_data_set_content_type (
+    response_data, gsad_http_guess_content_type (path));
 
   if (stat (path, &buf))
     {
@@ -1017,7 +1017,8 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
   gchar *envelope = g_string_free (string, FALSE);
 
   cmd_response_data_set_content_length (response_data, strlen (envelope));
-  cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_APP_XML);
 
   return envelope;
 }
@@ -1056,7 +1057,8 @@ gsad_http_create_gsad_message (gsad_credentials_t *credentials,
   g_free (gsad_response);
 
   cmd_response_data_set_content_length (response_data, strlen (envelope));
-  cmd_response_data_set_content_type (response_data, GSAD_CONTENT_TYPE_APP_XML);
+  gsad_command_response_data_set_content_type (response_data,
+                                               GSAD_CONTENT_TYPE_APP_XML);
 
   return envelope;
 }

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -538,7 +538,7 @@ gsad_http_create_response (gsad_http_connection_t *connection, gchar *data,
   gsad_http_response_t *response;
   gsize len = 0;
 
-  len = cmd_response_data_get_content_length (response_data);
+  len = gsad_command_response_data_get_content_length (response_data);
   if (len == 0 && data)
     {
       len = strlen (data);
@@ -584,9 +584,9 @@ gsad_http_create_not_found_response (
   gsad_command_response_data_set_content_type (response_data,
                                                GSAD_CONTENT_TYPE_TEXT_HTML);
 
-  cmd_response_data_set_content_length (response_data, strlen (msg));
+  gsad_command_response_data_set_content_length (response_data, strlen (msg));
 
-  len = cmd_response_data_get_content_length (response_data);
+  len = gsad_command_response_data_get_content_length (response_data);
   response = MHD_create_response_from_buffer (len, msg, MHD_RESPMEM_MUST_COPY);
   return response;
 }
@@ -1018,7 +1018,8 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
 
   gchar *envelope = g_string_free (string, FALSE);
 
-  cmd_response_data_set_content_length (response_data, strlen (envelope));
+  gsad_command_response_data_set_content_length (response_data,
+                                                 strlen (envelope));
   gsad_command_response_data_set_content_type (response_data,
                                                GSAD_CONTENT_TYPE_APP_XML);
 
@@ -1058,7 +1059,8 @@ gsad_http_create_gsad_message (gsad_credentials_t *credentials,
                                      GSAD_VERSION, gsad_response);
   g_free (gsad_response);
 
-  cmd_response_data_set_content_length (response_data, strlen (envelope));
+  gsad_command_response_data_set_content_length (response_data,
+                                                 strlen (envelope));
   gsad_command_response_data_set_content_type (response_data,
                                                GSAD_CONTENT_TYPE_APP_XML);
 

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -457,7 +457,8 @@ gsad_http_send_response_for_content (gsad_http_connection_t *connection,
 gsad_http_result_t
 gsad_http_send_response (gsad_http_connection_t *connection,
                          gsad_http_response_t *response,
-                         cmd_response_data_t *response_data, const gchar *sid)
+                         gsad_command_response_data_t *response_data,
+                         const gchar *sid)
 {
   int ret;
   const gchar *content_disposition;
@@ -531,7 +532,8 @@ gsad_http_send_response (gsad_http_connection_t *connection,
  */
 gsad_http_result_t
 gsad_http_create_response (gsad_http_connection_t *connection, gchar *data,
-                           cmd_response_data_t *response_data, const gchar *sid)
+                           gsad_command_response_data_t *response_data,
+                           const gchar *sid)
 {
   gsad_http_response_t *response;
   gsize len = 0;
@@ -554,7 +556,8 @@ gsad_http_create_response (gsad_http_connection_t *connection, gchar *data,
  * @return A http response
  */
 gsad_http_response_t *
-gsad_http_create_not_found_response (cmd_response_data_t *response_data)
+gsad_http_create_not_found_response (
+  gsad_command_response_data_t *response_data)
 {
   gsad_http_response_t *response;
   int len;
@@ -639,7 +642,7 @@ gsad_http_send_reauthentication (gsad_http_connection_t *connection,
       msg = "";
     }
 
-  cmd_response_data_t *response_data = cmd_response_data_new ();
+  gsad_command_response_data_t *response_data = cmd_response_data_new ();
   cmd_response_data_set_status_code (response_data, http_status_code);
 
   gchar *xml = gsad_http_create_gsad_message (NULL, msg, response_data);
@@ -678,9 +681,9 @@ file_reader (void *cls, uint64_t pos, char *buf, int max)
  *         if file information could not be retrieved.
  */
 gsad_http_response_t *
-gsad_http_create_file_content_response (gsad_http_connection_t *connection,
-                                        const char *url, const char *path,
-                                        cmd_response_data_t *response_data)
+gsad_http_create_file_content_response (
+  gsad_http_connection_t *connection, const char *url, const char *path,
+  gsad_command_response_data_t *response_data)
 {
   char date_2822[DATE_2822_LEN];
   struct tm mtime;
@@ -974,7 +977,7 @@ serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,
  */
 char *
 gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
-                           cmd_response_data_t *response_data)
+                           gsad_command_response_data_t *response_data)
 {
   assert (credentials);
 
@@ -1030,7 +1033,7 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
 gchar *
 gsad_http_create_gsad_message (gsad_credentials_t *credentials,
                                const char *message,
-                               cmd_response_data_t *response_data)
+                               gsad_command_response_data_t *response_data)
 {
   gchar *gsad_response = g_markup_printf_escaped ("<gsad_response>"
                                                   "<message>%s</message>"

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -486,7 +486,7 @@ gsad_http_send_response (gsad_http_connection_t *connection,
     }
 
   content_disposition =
-    cmd_response_data_get_content_disposition (response_data);
+    gsad_command_response_data_get_content_disposition (response_data);
 
   if (content_disposition != NULL)
     {

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -11,7 +11,7 @@
 #ifndef _GSAD_HTTP_H
 #define _GSAD_HTTP_H
 
-#include "gsad_cmd.h"             /* for cmd_response_data_t */
+#include "gsad_cmd.h"             /* for gsad_commad_response_data_t */
 #include "gsad_connection_info.h" /* for gsad_connection_info_t */
 #include "gsad_content_type.h"    /* for content_type_t */
 #include "gsad_credentials.h"     /* for credentials_t */
@@ -115,11 +115,11 @@ gsad_http_guess_content_type (const gchar *);
 
 gsad_http_result_t
 gsad_http_create_response (gsad_http_connection_t *, gchar *,
-                           cmd_response_data_t *, const gchar *);
+                           gsad_command_response_data_t *, const gchar *);
 
 gsad_http_result_t
 gsad_http_send_response (gsad_http_connection_t *, gsad_http_response_t *,
-                         cmd_response_data_t *, const gchar *);
+                         gsad_command_response_data_t *, const gchar *);
 
 /**
  * @brief Content types.
@@ -168,10 +168,11 @@ gsad_http_add_content_type_header (gsad_http_response_t *, content_type_t *);
 
 gsad_http_response_t *
 gsad_http_create_file_content_response (gsad_http_connection_t *, const gchar *,
-                                        const gchar *, cmd_response_data_t *);
+                                        const gchar *,
+                                        gsad_command_response_data_t *);
 
 gsad_http_response_t *
-gsad_http_create_not_found_response (cmd_response_data_t *);
+gsad_http_create_not_found_response (gsad_command_response_data_t *);
 
 /* helper functions required in gsad_http */
 int
@@ -195,10 +196,10 @@ exec_gmp_post (gsad_http_connection_t *connection,
 
 gchar *
 gsad_http_create_gsad_message (gsad_credentials_t *, const gchar *,
-                               cmd_response_data_t *);
+                               gsad_command_response_data_t *);
 
 gchar *
 gsad_http_create_envelope (gsad_credentials_t *, gchar *,
-                           cmd_response_data_t *);
+                           gsad_command_response_data_t *);
 
 #endif /* _GSAD_HTTP_H */

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -11,11 +11,11 @@
 #ifndef _GSAD_HTTP_H
 #define _GSAD_HTTP_H
 
-#include "gsad_cmd.h"             /* for gsad_commad_response_data_t */
-#include "gsad_connection_info.h" /* for gsad_connection_info_t */
-#include "gsad_content_type.h"    /* for content_type_t */
-#include "gsad_credentials.h"     /* for credentials_t */
-#include "gsad_user.h"            /* for gsad_user_t */
+#include "gsad_command_response_data.h" /* for gsad_command_response_data_t */
+#include "gsad_connection_info.h"       /* for gsad_connection_info_t */
+#include "gsad_content_type.h"          /* for content_type_t */
+#include "gsad_credentials.h"           /* for credentials_t */
+#include "gsad_user.h"                  /* for gsad_user_t */
 
 #include <glib.h>
 #include <microhttpd.h>

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -554,8 +554,8 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
         {
           g_info ("%s: failed to get system report for sensor %s", __func__,
                   slave_id);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
           res = gsad_http_create_gsad_message (
             credentials,
             "An internal error occurred. "
@@ -564,8 +564,8 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
         }
       break;
     case 1: /* manager closed connection */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -581,8 +581,8 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
 
       break;
     case 3: /* timeout */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -591,8 +591,8 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
         response_data);
       break;
     case 4: /* failed to connect to manager */
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -601,8 +601,8 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
         response_data);
       break;
     default:
-      cmd_response_data_set_status_code (response_data,
-                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_http_create_gsad_message (
         credentials,
         "An internal error occurred. "
@@ -778,8 +778,8 @@ gsad_http_handle_static_content (gsad_http_handler_t *handler_next,
             MHD_create_response_from_buffer (0, NULL, MHD_RESPMEM_PERSISTENT);
           MHD_add_response_header (response, "Location", new_url);
           response_data = gsad_command_response_data_new ();
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_MOVED_PERMANENTLY);
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_MOVED_PERMANENTLY);
           g_free (path);
           g_free (new_url);
           return gsad_http_send_response (connection, response, response_data,
@@ -856,7 +856,7 @@ gsad_http_handle_static_config (gsad_http_handler_t *handler_next,
   g_free (path);
 
   // send empty config
-  cmd_response_data_set_status_code (response_data, MHD_HTTP_OK);
+  gsad_command_response_data_set_status_code (response_data, MHD_HTTP_OK);
   return gsad_http_create_response (connection, g_strdup (""), response_data,
                                     NULL);
 }

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -521,7 +521,7 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
   const char *slave_id;
   gchar *res;
   gvm_connection_t con;
-  cmd_response_data_t *response_data;
+  gsad_command_response_data_t *response_data;
 
   g_debug ("Request for system report url %s", url);
 
@@ -648,7 +648,7 @@ gsad_http_handle_index (gsad_http_handler_t *handler_next, void *handler_data,
                         gsad_connection_info_t *con_info, void *data)
 {
   gsad_http_response_t *response;
-  cmd_response_data_t *response_data;
+  gsad_command_response_data_t *response_data;
 
   response_data = cmd_response_data_new ();
   cmd_response_data_set_allow_caching (response_data, FALSE);
@@ -692,7 +692,7 @@ gsad_http_handle_static_file (gsad_http_handler_t *handler_next,
   gchar *path;
   gsad_http_response_t *response;
   char *default_file = "index.html";
-  cmd_response_data_t *response_data;
+  gsad_command_response_data_t *response_data;
   const gchar *url = gsad_connection_info_get_url (con_info);
 
   /** @todo validation, URL length restriction (allows you to view ANY
@@ -748,7 +748,7 @@ gsad_http_handle_static_content (gsad_http_handler_t *handler_next,
   gchar *path;
   gsad_http_response_t *response;
   char *default_file = "index.html";
-  cmd_response_data_t *response_data;
+  gsad_command_response_data_t *response_data;
   const gchar *url = gsad_connection_info_get_url (con_info);
 
   /** @todo validation, URL length restriction (allows you to view ANY
@@ -826,7 +826,7 @@ gsad_http_handle_static_config (gsad_http_handler_t *handler_next,
 {
   gchar *path;
   gsad_http_response_t *response;
-  cmd_response_data_t *response_data;
+  gsad_command_response_data_t *response_data;
   const gchar *url = gsad_connection_info_get_url (con_info);
 
   /* Ensure that url is relative. */
@@ -887,7 +887,7 @@ gsad_http_handle_not_found (gsad_http_handler_t *handler_next,
 
   g_debug ("Returning not found for url %s", url);
 
-  cmd_response_data_t *response_data = cmd_response_data_new ();
+  gsad_command_response_data_t *response_data = cmd_response_data_new ();
   gsad_http_response_t *response =
     gsad_http_create_not_found_response (response_data);
   return gsad_http_send_response (connection, response, response_data, NULL);

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -651,7 +651,7 @@ gsad_http_handle_index (gsad_http_handler_t *handler_next, void *handler_data,
   gsad_command_response_data_t *response_data;
 
   response_data = gsad_command_response_data_new ();
-  cmd_response_data_set_allow_caching (response_data, FALSE);
+  gsad_command_response_data_set_allow_caching (response_data, FALSE);
 
   const gchar *url = gsad_connection_info_get_url (con_info);
 
@@ -713,7 +713,7 @@ gsad_http_handle_static_file (gsad_http_handler_t *handler_next,
   g_debug ("Requesting url %s for static path %s", url, path);
 
   response_data = gsad_command_response_data_new ();
-  cmd_response_data_set_allow_caching (response_data, TRUE);
+  gsad_command_response_data_set_allow_caching (response_data, TRUE);
 
   response = gsad_http_create_file_content_response (connection, url, path,
                                                      response_data);
@@ -792,7 +792,7 @@ gsad_http_handle_static_content (gsad_http_handler_t *handler_next,
     }
 
   response_data = gsad_command_response_data_new ();
-  cmd_response_data_set_allow_caching (response_data, TRUE);
+  gsad_command_response_data_set_allow_caching (response_data, TRUE);
 
   response = gsad_http_create_file_content_response (connection, url, path,
                                                      response_data);
@@ -842,7 +842,7 @@ gsad_http_handle_static_config (gsad_http_handler_t *handler_next,
   response_data = gsad_command_response_data_new ();
 
   // don't cache config file
-  cmd_response_data_set_allow_caching (response_data, FALSE);
+  gsad_command_response_data_set_allow_caching (response_data, FALSE);
 
   if (g_file_test (path, G_FILE_TEST_EXISTS))
     {

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -540,7 +540,7 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
       return MHD_NO;
     }
 
-  response_data = cmd_response_data_new ();
+  response_data = gsad_command_response_data_new ();
 
   /* Connect to manager */
   switch (gsad_manager_connect_with_credentials (&con, credentials))
@@ -574,7 +574,7 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
         response_data);
       break;
     case 2: /* authentication failed */
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
       gsad_credentials_free (credentials);
       return gsad_http_send_reauthentication (connection, MHD_HTTP_UNAUTHORIZED,
                                               LOGIN_FAILED);
@@ -617,7 +617,7 @@ gsad_http_handle_system_report (gsad_http_handler_t *handler_next,
       gsad_credentials_free (credentials);
       g_warning ("%s: failed to get system reports, dropping request",
                  __func__);
-      cmd_response_data_free (response_data);
+      gsad_command_response_data_free (response_data);
       return MHD_NO;
     }
 
@@ -650,7 +650,7 @@ gsad_http_handle_index (gsad_http_handler_t *handler_next, void *handler_data,
   gsad_http_response_t *response;
   gsad_command_response_data_t *response_data;
 
-  response_data = cmd_response_data_new ();
+  response_data = gsad_command_response_data_new ();
   cmd_response_data_set_allow_caching (response_data, FALSE);
 
   const gchar *url = gsad_connection_info_get_url (con_info);
@@ -712,7 +712,7 @@ gsad_http_handle_static_file (gsad_http_handler_t *handler_next,
 
   g_debug ("Requesting url %s for static path %s", url, path);
 
-  response_data = cmd_response_data_new ();
+  response_data = gsad_command_response_data_new ();
   cmd_response_data_set_allow_caching (response_data, TRUE);
 
   response = gsad_http_create_file_content_response (connection, url, path,
@@ -777,7 +777,7 @@ gsad_http_handle_static_content (gsad_http_handler_t *handler_next,
           response =
             MHD_create_response_from_buffer (0, NULL, MHD_RESPMEM_PERSISTENT);
           MHD_add_response_header (response, "Location", new_url);
-          response_data = cmd_response_data_new ();
+          response_data = gsad_command_response_data_new ();
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_MOVED_PERMANENTLY);
           g_free (path);
@@ -791,7 +791,7 @@ gsad_http_handle_static_content (gsad_http_handler_t *handler_next,
       g_free (old_path);
     }
 
-  response_data = cmd_response_data_new ();
+  response_data = gsad_command_response_data_new ();
   cmd_response_data_set_allow_caching (response_data, TRUE);
 
   response = gsad_http_create_file_content_response (connection, url, path,
@@ -839,7 +839,7 @@ gsad_http_handle_static_config (gsad_http_handler_t *handler_next,
 
   g_debug ("Requesting url %s for static config path %s", url, path);
 
-  response_data = cmd_response_data_new ();
+  response_data = gsad_command_response_data_new ();
 
   // don't cache config file
   cmd_response_data_set_allow_caching (response_data, FALSE);
@@ -887,7 +887,8 @@ gsad_http_handle_not_found (gsad_http_handler_t *handler_next,
 
   g_debug ("Returning not found for url %s", url);
 
-  gsad_command_response_data_t *response_data = cmd_response_data_new ();
+  gsad_command_response_data_t *response_data =
+    gsad_command_response_data_new ();
   gsad_http_response_t *response =
     gsad_http_create_not_found_response (response_data);
   return gsad_http_send_response (connection, response, response_data, NULL);


### PR DESCRIPTION
## What

Consistent naming for gsad command response data

## Why
Use `gsad_` prefix for all data and functions originating in gsad.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


