### PR TITLE
Remove unused ctime_r_strip_newline function

### DIFF
--- a/src/gsad_base.c
+++ b/src/gsad_base.c
@@ -68,25 +68,3 @@ set_chroot_state (int state)
 {
   chroot_state = state;
 }
-
-/**
- * @brief Return string from ctime_r with newline replaces with terminator.
- *
- * @param[in]  time    Time.
- * @param[out] string  Time string.
- *
- * @return Return from ctime_r applied to time, with newline stripped off.
- */
-char *
-ctime_r_strip_newline (time_t *time, char *string)
-{
-  struct tm tm;
-
-  if (localtime_r (time, &tm) == NULL
-      || (strftime (string, 199, "%c %Z", &tm) == 0))
-    {
-      string[0] = '\0';
-      return string;
-    }
-  return string;
-}

--- a/src/gsad_base.h
+++ b/src/gsad_base.h
@@ -26,7 +26,4 @@ gsad_base_cleanup ();
 void
 set_chroot_state (int);
 
-char *
-ctime_r_strip_newline (time_t *, char *);
-
 #endif /* not _GSAD_BASE_H */


### PR DESCRIPTION


## What

Remove unused ctime_r_strip_newline function

## Why

This function is not used anymore.

