### PR TITLE
add: Add GSAD wrapper for GET_REPORT_OPERATING_SYSTEMS

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -771,7 +771,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
               gsad_credentials_t *credentials)
 {
   const gchar *cmd = NULL;
-  const int CMD_MAX_SIZE = 27; /* delete_trash_lsc_credential */
+  const int CMD_MAX_SIZE = 33; /* get_report_operating_systems_gmp */
   params_t *params = gsad_connection_info_get_params (con_info);
   gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
   gvm_connection_t connection;
@@ -1027,6 +1027,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_report_applications)
   ELSE (get_report_errors)
   ELSE (get_report_hosts)
+  ELSE (get_report_operating_systems)
   ELSE (get_report_ports)
   ELSE (get_report_tls_certificates)
   ELSE (get_reports)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -9886,6 +9886,101 @@ get_report_hosts_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Get report operating systems and return the result.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Username and password for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data return for the HTTP response.
+ *
+ * @return Report operating systems XML.
+ */
+char *
+get_report_operating_systems_gmp (gvm_connection_t *connection,
+                                  gsad_credentials_t *credentials,
+                                  params_t *params,
+                                  gsad_command_response_data_t *response_data)
+{
+  GString *xml;
+  entity_t entity;
+  const char *report_id;
+  const char *filter;
+  const char *filter_id;
+  gboolean details, ignore_pagination;
+  int ret;
+
+  details = params_value_bool (params, "details");
+  ignore_pagination = params_value_bool (params, "ignore_pagination");
+
+  report_id = params_value (params, "report_id");
+  filter = params_value (params, "filter");
+  filter_id = params_value (params, "filter_id");
+
+  CHECK_VARIABLE_INVALID (report_id, "Get Report Operating Systems");
+
+  if (filter == NULL || filter_id)
+    filter = "";
+
+  ret = gvm_connection_sendf_xml (connection,
+                                  "<get_report_operating_systems"
+                                  " report_id=\"%s\""
+                                  " details=\"%d\""
+                                  " ignore_pagination=\"%d\""
+                                  " filter=\"%s\""
+                                  " filt_id=\"%s\"/>",
+                                  report_id, details, ignore_pagination, filter,
+                                  filter_id ? filter_id : FILT_ID_NONE);
+
+  if (ret == -1)
+    {
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting report operating systems. "
+        "The report operating systems could not be delivered. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
+
+  xml = g_string_new ("<get_report_operating_systems>");
+
+  entity = NULL;
+  if (read_entity_and_string_c (connection, &entity, &xml))
+    {
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting report operating systems. "
+        "The report operating systems could not be delivered. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
+
+  if (gmp_success (entity) != 1)
+    {
+      gchar *message;
+
+      set_http_status_from_entity (entity, response_data);
+
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
+
+      g_string_free (xml, TRUE);
+      free_entity (entity);
+      return message;
+    }
+
+  free_entity (entity);
+
+  g_string_append (xml, "</get_report_operating_systems>");
+
+  return envelope_gmp (connection, credentials, params,
+                       g_string_free (xml, FALSE), response_data);
+}
+
+/**
  * @brief Get report ports and return the result.
  *
  * @param[in]  connection      Connection to manager.

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -88,6 +88,9 @@ char *
 get_report_hosts_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                       gsad_command_response_data_t *);
 char *
+get_report_operating_systems_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                  params_t *, gsad_command_response_data_t *);
+char *
 get_report_ports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                       gsad_command_response_data_t *);
 char *

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -177,6 +177,7 @@ gsad_init_validator ()
                      "|(get_report_applications)"
                      "|(get_report_errors)"
                      "|(get_report_hosts)"
+                     "|(get_report_operating_systems)"
                      "|(get_report_ports)"
                      "|(get_report_tls_certificates)"
                      "|(get_reports)"


### PR DESCRIPTION
## What

Add a GSAD handler to fetch report applications via GMP and return the XML response.


## Why

To enable retrieving report applications data through the GSAD API for clients.

## References

GEA-1710


