### PR TITLE
Fix: free args in gsad_args test

### DIFF
--- a/src/gsad_args_tests.c
+++ b/src/gsad_args_tests.c
@@ -1049,6 +1049,7 @@ Ensure (gsad_args, should_parse_tls_certificate_filename)
   args = gsad_args_new ();
   char *argv2[] = {"gsad"};
   gsad_args_parse (1, argv2, args);
+  gsad_args_free (args);
 
   // command line argument should override env variable
   args = gsad_args_new ();


### PR DESCRIPTION
## What

Close leak in gsad_args test `should_parse_tls_certificate_filename`.

## Why

Makes it easier to see actual leaks in `-fsanitize=address` output.