### PR TITLE
Convert save_my_settings into standard gmp function

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -453,12 +453,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (save_credential)
   ELSE (save_filter)
   ELSE (save_group)
-  else if (!strcmp (cmd, "save_my_settings"))
-  {
-    res = save_my_settings_gmp (
-      &connection, credentials, gsad_connection_info_get_params (con_info),
-      gsad_connection_info_get_language (con_info), response_data);
-  }
+  ELSE (save_my_settings)
   ELSE (save_license)
   ELSE (save_note)
   ELSE (save_oci_image_target)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -13961,7 +13961,6 @@ send_settings_filters (gvm_connection_t *connection, params_t *data,
  * @param[in]  connection     Connection to manager.
  * @param[in]  credentials  Credentials of user issuing the action.
  * @param[in]  params       Request parameters.
- * @param[in]  accept_language  Accept-Language, from browser.
  * @param[out] response_data  Extra data return for the HTTP response.
  *
  * @return Enveloped XML object.
@@ -13969,7 +13968,6 @@ send_settings_filters (gvm_connection_t *connection, params_t *data,
 char *
 save_my_settings_gmp (gvm_connection_t *connection,
                       gsad_credentials_t *credentials, params_t *params,
-                      const gchar *accept_language,
                       gsad_command_response_data_t *response_data)
 {
   const char *lang, *text, *old_passwd, *passwd, *max;

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -761,7 +761,7 @@ get_settings_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                   gsad_command_response_data_t *);
 char *
 save_my_settings_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                      const gchar *, gsad_command_response_data_t *);
+                      gsad_command_response_data_t *);
 char *
 get_setting_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                  gsad_command_response_data_t *);


### PR DESCRIPTION


## What
Convert save_my_settings into standard gmp function

## Why

The accept language argument of save_my_settings_gmp is not used at all. Therefore the function can be converted into a standard gmp function with the standard arguments.

