### PR TITLE
Remove language from connection info struct

### DIFF
--- a/src/gsad_connection_info.c
+++ b/src/gsad_connection_info.c
@@ -153,41 +153,6 @@ gsad_connection_info_set_cookie (gsad_connection_info_t *con_info,
 }
 
 /**
- * @brief Get the language of a connection information object.
- *
- * @param[in] con_info Connection information.
- *
- * @return Language of the connection information, or NULL if not set. The
- * language is owned by the connection information and should not be freed by
- * the caller.
- */
-const gchar *
-gsad_connection_info_get_language (const gsad_connection_info_t *con_info)
-{
-  g_return_val_if_fail (con_info != NULL, NULL);
-  return con_info->language;
-}
-
-/**
- * @brief Set the language of a connection information object.
- *
- * @param[in] con_info Connection information.
- * @param[in] language Language to set. The connection information will copy the
- * language and take ownership of the copy. The connection information will free
- * the copy when the connection information is freed. The caller retains
- * ownership of the original language and is responsible for freeing it if
- * necessary.
- */
-void
-gsad_connection_info_set_language (gsad_connection_info_t *con_info,
-                                   const gchar *language)
-{
-  g_return_if_fail (con_info != NULL);
-  g_free (con_info->language);
-  con_info->language = g_strdup (language);
-}
-
-/**
  * @brief Get the URL of a connection information object.
  *
  * @param[in] con_info Connection information.

--- a/src/gsad_connection_info.h
+++ b/src/gsad_connection_info.h
@@ -66,12 +66,6 @@ void
 gsad_connection_info_set_cookie (gsad_connection_info_t *, const gchar *);
 
 const gchar *
-gsad_connection_info_get_language (const gsad_connection_info_t *);
-
-void
-gsad_connection_info_set_language (gsad_connection_info_t *, const gchar *);
-
-const gchar *
 gsad_connection_info_get_url (const gsad_connection_info_t *);
 
 #endif /* _GSAD_CONNECTION_INFO_H */

--- a/src/gsad_connection_info_tests.c
+++ b/src/gsad_connection_info_tests.c
@@ -28,7 +28,6 @@ Ensure (gsad_connection_info, should_allow_to_create_connection_info_for_post)
   assert_that (gsad_connection_info_get_params (con_info), is_not_null);
   assert_that (gsad_connection_info_get_postprocessor (con_info), is_null);
   assert_that (gsad_connection_info_get_cookie (con_info), is_null);
-  assert_that (gsad_connection_info_get_language (con_info), is_null);
   assert_that (gsad_connection_info_get_url (con_info),
                is_equal_to_string ("/some-url"));
 
@@ -46,7 +45,6 @@ Ensure (gsad_connection_info, should_allow_to_create_connection_info_for_get)
   assert_that (gsad_connection_info_get_params (con_info), is_not_null);
   assert_that (gsad_connection_info_get_postprocessor (con_info), is_null);
   assert_that (gsad_connection_info_get_cookie (con_info), is_null);
-  assert_that (gsad_connection_info_get_language (con_info), is_null);
   assert_that (gsad_connection_info_get_url (con_info),
                is_equal_to_string ("/some-url"));
 
@@ -69,7 +67,6 @@ Ensure (gsad_connection_info, should_allow_to_create_connection_info_unknown)
   assert_that (gsad_connection_info_get_params (con_info), is_not_null);
   assert_that (gsad_connection_info_get_postprocessor (con_info), is_null);
   assert_that (gsad_connection_info_get_cookie (con_info), is_null);
-  assert_that (gsad_connection_info_get_language (con_info), is_null);
   assert_that (gsad_connection_info_get_url (con_info),
                is_equal_to_string ("/some-url"));
 
@@ -106,22 +103,6 @@ Ensure (gsad_connection_info, should_set_and_get_cookie)
   assert_that (gsad_connection_info_get_cookie (con_info), is_null);
 }
 
-Ensure (gsad_connection_info, should_set_and_get_language)
-{
-  gsad_connection_info_t *con_info =
-    gsad_connection_info_new (METHOD_TYPE_POST, "/some-url");
-
-  gsad_connection_info_set_language (con_info, "en-US");
-  assert_that (gsad_connection_info_get_language (con_info),
-               is_equal_to_string ("en-US"));
-
-  gsad_connection_info_free (con_info);
-
-  con_info = NULL;
-  gsad_connection_info_set_language (con_info, "en-US");
-  assert_that (gsad_connection_info_get_language (con_info), is_null);
-}
-
 int
 main (int argc, char **argv)
 {
@@ -137,8 +118,6 @@ main (int argc, char **argv)
                          should_allow_to_create_connection_info_unknown);
   add_test_with_context (suite, gsad_connection_info,
                          should_set_and_get_cookie);
-  add_test_with_context (suite, gsad_connection_info,
-                         should_set_and_get_language);
   add_test_with_context (suite, gsad_connection_info,
                          should_allow_to_get_params);
   add_test_with_context (suite, gsad_connection_info,

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -478,9 +478,6 @@ gsad_http_handle_gmp_post (gsad_http_handler_t *handler_next,
       return MHD_YES;
     }
 
-  gsad_connection_info_set_language (
-    con_info, accept_language_to_env_fmt (accept_language));
-
   if (gsad_http_get_client_address (connection, client_address))
     {
       gsad_http_send_response_for_content (


### PR DESCRIPTION


## What

Remove language from connection info struct

## Why

The language was not used actually and therefore can be safely removed.

