### PR TITLE
Add new `/login` URL POST handler

### DIFF
--- a/src/gsad_http_handle_request.c
+++ b/src/gsad_http_handle_request.c
@@ -109,6 +109,12 @@ gsad_http_request_init_handlers (gsad_settings_t *gsad_settings)
       next = gsad_http_handler_add (next, manual_handler);
     }
 
+  // Create /login handler chain.
+  gsad_http_handler_t *login_handler = gsad_http_url_handler_new (
+    "^/login/?$",
+    gsad_http_method_handler_new_post_from_func (gsad_http_handle_login));
+  next = gsad_http_handler_add (next, login_handler);
+
   // Create /system_report handler
   // chain.
   gsad_http_handler_t *system_report_handler =

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -407,6 +407,28 @@ gsad_http_handle_logout (gsad_http_handler_t *handler_next, void *handler_data,
     0);
 }
 
+gsad_http_result_t
+gsad_http_handle_login (gsad_http_handler_t *handler_next, void *handler_data,
+                        gsad_http_connection_t *connection,
+                        gsad_connection_info_t *con_info, void *data)
+{
+  params_t *params = gsad_connection_info_get_params (con_info);
+  gsad_command_response_data_t *response_data =
+    gsad_command_response_data_new ();
+  char client_address[INET6_ADDRSTRLEN];
+
+  params_mhd_validate (params);
+
+  if (gsad_http_get_client_address (connection, client_address))
+    {
+      gsad_http_send_response_for_content (
+        connection, UTF8_ERROR_PAGE ("'X-Real-IP' header"),
+        MHD_HTTP_BAD_REQUEST, NULL, GSAD_CONTENT_TYPE_TEXT_HTML, NULL, 0);
+      gsad_command_response_data_free (response_data);
+      return MHD_YES;
+    }
+  return login (connection, params, response_data, client_address);
+}
 /**
  * @brief Handler for processing /gmp GET requests
  *

--- a/src/gsad_http_handler_functions.h
+++ b/src/gsad_http_handler_functions.h
@@ -39,6 +39,10 @@ gsad_http_handle_logout (gsad_http_handler_t *, void *,
                          void *);
 
 gsad_http_result_t
+gsad_http_handle_login (gsad_http_handler_t *, void *, gsad_http_connection_t *,
+                        gsad_connection_info_t *, void *);
+
+gsad_http_result_t
 gsad_http_handle_system_report (gsad_http_handler_t *, void *,
                                 gsad_http_connection_t *,
                                 gsad_connection_info_t *, void *);


### PR DESCRIPTION


## What

Add new `/login` URL POST handler

## Why

Use an explicit URL for the login process. Currently the `/gmp` POST handler has a special code path for the login. By moving out the login path from this handler in near future we can reduce the complexity of the GMP POST handler and reuse more code from the GMP GET handler.


