### PR TITLE
Remove `/gmp?cmd=login` endpoint

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -206,11 +206,6 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   g_debug ("Handling GMP command '%s' for HTTP POST", cmd);
 
-  if (str_equal (cmd, "login"))
-    {
-      return login (con, params, response_data, client_address);
-    }
-
   /* Check the session. */
 
   if (params_value (params, "token") == NULL)


### PR DESCRIPTION


## What

Remove `/gmp?cmd=login` endpoint

## Why

The endpoint got replaced by `/login`. It requires an up to date GSA version.

## References
Requires [GSA >= 27.0.0](https://github.com/greenbone/gsa/releases/tag/v27.0.0)


