### PR TITLE
Optional User Session

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1139,7 +1139,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gsad_user_t *user = gsad_credentials_get_user (credentials);
 
   return gsad_http_send_response (con, response, response_data,
-                                  gsad_user_get_cookie (user));
+                                  user ? gsad_user_get_cookie (user) : NULL);
 }
 
 /**

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -797,21 +797,6 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       return gsad_http_create_response (con, res, response_data, NULL);
     }
 
-  /* Set the timezone. */
-
-  gsad_user_t *user = gsad_credentials_get_user (credentials);
-  const gchar *timezone = gsad_user_get_timezone (user);
-
-  if (timezone)
-    {
-      if (setenv ("TZ", timezone, 1) == -1)
-        {
-          g_critical ("%s: failed to set TZ\n", __func__);
-          exit (EXIT_FAILURE);
-        }
-      tzset ();
-    }
-
   /* Connect to manager */
   switch (gsad_manager_connect_with_credentials (&connection, credentials))
     {
@@ -1150,6 +1135,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     {
       gvm_connection_close (&connection);
     }
+
+  gsad_user_t *user = gsad_credentials_get_user (credentials);
 
   return gsad_http_send_response (con, response, response_data,
                                   gsad_user_get_cookie (user));

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -288,19 +288,6 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
 
   new_sid = g_strdup (gsad_user_get_cookie (user));
 
-  /* Set the timezone. */
-
-  const gchar *timezone = gsad_user_get_timezone (user);
-  if (timezone)
-    {
-      if (setenv ("TZ", timezone, 1) == -1)
-        {
-          g_critical ("%s: failed to set TZ\n", __func__);
-          exit (EXIT_FAILURE);
-        }
-      tzset ();
-    }
-
   /* Connect to manager */
   switch (gsad_manager_connect_with_credentials (&connection, credentials))
     {

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -169,22 +169,20 @@ free_resources (void *cls, struct MHD_Connection *connection, void **con_cls,
  *
  * @param[in]   con             HTTP connection
  * @param[in]   con_info        Connection info.
- * @param[in]   client_address  Client address.
+ * @param[in]   credentials     Client credentials.
  *
  * @return MHD_YES on success, MHD_NO on error.
  */
 gsad_http_result_t
 exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
-               const gchar *client_address)
+               gsad_credentials_t *credentials)
 {
-  int ret;
-  gsad_user_t *user;
-  gsad_credentials_t *credentials = NULL;
-  gchar *res = NULL, *new_sid = NULL;
-  const gchar *cmd, *caller;
+  gchar *res = NULL;
+  const gchar *cmd;
   gvm_connection_t connection;
   gsad_command_response_data_t *response_data =
     gsad_command_response_data_new ();
+  gsad_user_t *user = gsad_credentials_get_user (credentials);
 
   params_t *params = gsad_connection_info_get_params (con_info);
   params_mhd_validate (params);
@@ -201,92 +199,10 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
         "An internal error occurred inside GSA daemon. "
         "Diagnostics: Invalid command.",
         response_data);
-      return gsad_http_create_response (con, res, response_data, new_sid);
+      return gsad_http_create_response (con, res, response_data, NULL);
     }
 
   g_debug ("Handling GMP command '%s' for HTTP POST", cmd);
-
-  /* Check the session. */
-
-  if (params_value (params, "token") == NULL)
-    {
-      gsad_command_response_data_set_status_code (response_data,
-                                                  MHD_HTTP_BAD_REQUEST);
-
-      if (params_given (params, "token") == 0)
-        res = gsad_http_create_gsad_message (
-          NULL,
-          "An internal error occurred inside GSA daemon. "
-          "Diagnostics: Token missing.",
-          response_data);
-      else
-        res = gsad_http_create_gsad_message (
-          NULL,
-          "An internal error occurred inside GSA daemon. "
-          "Diagnostics: Token bad.",
-          response_data);
-
-      return gsad_http_create_response (con, res, response_data, NULL);
-    }
-
-  ret = gsad_user_session_find (gsad_connection_info_get_cookie (con_info),
-                                params_value (params, "token"), client_address,
-                                &user);
-  if (ret == USER_BAD_TOKEN)
-    {
-      gsad_command_response_data_set_status_code (response_data,
-                                                  MHD_HTTP_BAD_REQUEST);
-      res = gsad_http_create_gsad_message (
-        NULL,
-        "An internal error occurred inside GSA daemon. "
-        "Diagnostics: Bad token.",
-        response_data);
-      return gsad_http_create_response (con, res, response_data, NULL);
-    }
-
-  if (ret == USER_EXPIRED_TOKEN)
-    {
-      caller = params_value (params, "caller");
-
-      if (caller && g_utf8_validate (caller, -1, NULL) == FALSE)
-        {
-          caller = NULL;
-          g_warning ("%s - caller is not valid UTF-8", __func__);
-        }
-
-      /* @todo Validate caller. */
-
-      gsad_command_response_data_free (response_data);
-
-      return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
-                                              SESSION_EXPIRED);
-    }
-
-  if (ret == USER_BAD_MISSING_COOKIE || ret == USER_IP_ADDRESS_MISSMATCH)
-    {
-      gsad_command_response_data_free (response_data);
-
-      return gsad_http_send_reauthentication (con, MHD_HTTP_UNAUTHORIZED,
-                                              BAD_MISSING_COOKIE);
-    }
-
-  if (ret == USER_GMP_DOWN)
-    {
-      gsad_command_response_data_free (response_data);
-
-      return gsad_http_send_reauthentication (con, MHD_HTTP_SERVICE_UNAVAILABLE,
-                                              GMP_SERVICE_DOWN);
-    }
-
-  /* From here, the user is authenticated. */
-
-  /* The caller of a POST is usually the caller of the page that the POST form
-   * was on. */
-  credentials = gsad_credentials_new ();
-  gsad_credentials_set_user (credentials, user);
-  gsad_credentials_set_jwt (credentials, gsad_user_get_jwt (user));
-
-  new_sid = g_strdup (gsad_user_get_cookie (user));
 
   /* Connect to manager */
   switch (gsad_manager_connect_with_credentials (&connection, credentials))
@@ -344,7 +260,10 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     }
 
   /* always renew session for http post */
-  gsad_user_session_renew_timeout (user);
+  if (user)
+    {
+      gsad_user_session_renew_timeout (user);
+    }
 
   /* Handle the usual commands. */
   if (0)
@@ -475,14 +394,9 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       response_data);
   }
 
-  ret = gsad_http_create_response (con, res, response_data, new_sid);
-
-  gsad_user_free (user);
-  gsad_credentials_free (credentials);
   gvm_connection_close (&connection);
-  g_free (new_sid);
-
-  return ret;
+  return gsad_http_create_response (con, res, response_data,
+                                    user ? gsad_user_get_cookie (user) : NULL);
 }
 
 /*

--- a/src/gsad_connection_info.c
+++ b/src/gsad_connection_info.c
@@ -8,8 +8,6 @@
 struct gsad_connection_info
 {
   gsad_method_type_t method_type;          ///< 1=POST, 2=GET.
-  gchar *cookie;                           ///< Value of SID cookie param.
-  gchar *language;                         ///< Language code e.g. en
   gchar *url;                              ///< Request URL.
   params_t *params;                        ///< Request parameters.
   struct MHD_PostProcessor *postprocessor; ///< POST processor.
@@ -26,8 +24,6 @@ gsad_connection_info_new (gsad_method_type_t method_type, const gchar *url)
   gsad_connection_info_t *con_info = g_malloc (sizeof (gsad_connection_info_t));
   con_info->postprocessor = NULL;
   con_info->params = params_new ();
-  con_info->cookie = NULL;
-  con_info->language = NULL;
   con_info->method_type = method_type;
   con_info->url = g_strdup (url);
   return con_info;
@@ -48,8 +44,6 @@ gsad_connection_info_free (gsad_connection_info_t *con_info)
     MHD_destroy_post_processor (con_info->postprocessor);
 
   params_free (con_info->params);
-  g_free (con_info->cookie);
-  g_free (con_info->language);
   g_free (con_info->url);
   g_free (con_info);
 }
@@ -115,41 +109,6 @@ gsad_connection_info_set_postprocessor (gsad_connection_info_t *con_info,
   if (con_info->postprocessor != NULL)
     MHD_destroy_post_processor (con_info->postprocessor);
   con_info->postprocessor = postprocessor;
-}
-
-/**
- * @brief Get the cookie value of a connection information object.
- *
- * @param[in] con_info Connection information.
- *
- * @return Cookie value of the connection information, or NULL if not set. The
- * cookie value is owned by the connection information and should not be freed
- * by the caller.
- */
-const gchar *
-gsad_connection_info_get_cookie (const gsad_connection_info_t *con_info)
-{
-  g_return_val_if_fail (con_info != NULL, NULL);
-  return con_info->cookie;
-}
-
-/**
- * @brief Set the cookie value of a connection information object.
- *
- * @param[in] con_info Connection information.
- * @param[in] cookie Cookie value to set. The connection information will copy
- * the cookie value and take ownership of the copy. The connection information
- * will free the copy when the connection information is freed. The caller
- * retains ownership of the original cookie value and is responsible for freeing
- * it if necessary.
- */
-void
-gsad_connection_info_set_cookie (gsad_connection_info_t *con_info,
-                                 const gchar *cookie)
-{
-  g_return_if_fail (con_info != NULL);
-  g_free (con_info->cookie);
-  con_info->cookie = g_strdup (cookie);
 }
 
 /**

--- a/src/gsad_connection_info.h
+++ b/src/gsad_connection_info.h
@@ -60,12 +60,6 @@ gsad_connection_info_set_postprocessor (gsad_connection_info_t *,
                                         struct MHD_PostProcessor *);
 
 const gchar *
-gsad_connection_info_get_cookie (const gsad_connection_info_t *);
-
-void
-gsad_connection_info_set_cookie (gsad_connection_info_t *, const gchar *);
-
-const gchar *
 gsad_connection_info_get_url (const gsad_connection_info_t *);
 
 #endif /* _GSAD_CONNECTION_INFO_H */

--- a/src/gsad_connection_info_tests.c
+++ b/src/gsad_connection_info_tests.c
@@ -27,7 +27,6 @@ Ensure (gsad_connection_info, should_allow_to_create_connection_info_for_post)
                is_equal_to (METHOD_TYPE_POST));
   assert_that (gsad_connection_info_get_params (con_info), is_not_null);
   assert_that (gsad_connection_info_get_postprocessor (con_info), is_null);
-  assert_that (gsad_connection_info_get_cookie (con_info), is_null);
   assert_that (gsad_connection_info_get_url (con_info),
                is_equal_to_string ("/some-url"));
 
@@ -44,7 +43,6 @@ Ensure (gsad_connection_info, should_allow_to_create_connection_info_for_get)
                is_equal_to (METHOD_TYPE_GET));
   assert_that (gsad_connection_info_get_params (con_info), is_not_null);
   assert_that (gsad_connection_info_get_postprocessor (con_info), is_null);
-  assert_that (gsad_connection_info_get_cookie (con_info), is_null);
   assert_that (gsad_connection_info_get_url (con_info),
                is_equal_to_string ("/some-url"));
 
@@ -66,7 +64,6 @@ Ensure (gsad_connection_info, should_allow_to_create_connection_info_unknown)
                is_equal_to (METHOD_TYPE_UNKNOWN));
   assert_that (gsad_connection_info_get_params (con_info), is_not_null);
   assert_that (gsad_connection_info_get_postprocessor (con_info), is_null);
-  assert_that (gsad_connection_info_get_cookie (con_info), is_null);
   assert_that (gsad_connection_info_get_url (con_info),
                is_equal_to_string ("/some-url"));
 
@@ -87,22 +84,6 @@ Ensure (gsad_connection_info, should_allow_to_get_params)
   assert_that (gsad_connection_info_get_params (con_info), is_null);
 }
 
-Ensure (gsad_connection_info, should_set_and_get_cookie)
-{
-  gsad_connection_info_t *con_info =
-    gsad_connection_info_new (METHOD_TYPE_POST, "/some-url");
-
-  gsad_connection_info_set_cookie (con_info, "test_cookie");
-  assert_that (gsad_connection_info_get_cookie (con_info),
-               is_equal_to_string ("test_cookie"));
-
-  gsad_connection_info_free (con_info);
-
-  con_info = NULL;
-  gsad_connection_info_set_cookie (con_info, "test_cookie");
-  assert_that (gsad_connection_info_get_cookie (con_info), is_null);
-}
-
 int
 main (int argc, char **argv)
 {
@@ -116,8 +97,6 @@ main (int argc, char **argv)
                          should_allow_to_create_connection_info_for_get);
   add_test_with_context (suite, gsad_connection_info,
                          should_allow_to_create_connection_info_unknown);
-  add_test_with_context (suite, gsad_connection_info,
-                         should_set_and_get_cookie);
   add_test_with_context (suite, gsad_connection_info,
                          should_allow_to_get_params);
   add_test_with_context (suite, gsad_connection_info,

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -16590,6 +16590,7 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   current_user = gsad_credentials_get_user (credentials);
 
   if (login
+      && current_user
       /* gvmd forbids users from modifying their own names. */
       && strcmp (login, gsad_user_get_username (current_user)))
     {
@@ -16687,11 +16688,15 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
             {
               /* logout all other user sessions if new password was set,
                  authentication type has changed or username has changed */
-              gsad_session_remove_other_sessions (
-                gsad_user_get_token (current_user), old_login);
+              if (current_user)
+                {
+                  gsad_session_remove_other_sessions (
+                    gsad_user_get_token (current_user), old_login);
+                }
             }
 
-          if (str_equal (old_login, gsad_user_get_username (current_user)))
+          if (current_user
+              && str_equal (old_login, gsad_user_get_username (current_user)))
             {
               /* update username of current user */
               gsad_user_set_username (current_user, login);
@@ -16735,6 +16740,7 @@ save_user_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 
   if (gmp_success (entity)
       && (str_equal (modify_password, "2") || !str_equal (modify_password, "3"))
+      && current_user
       && str_equal (old_login, gsad_user_get_username (current_user)))
     {
       free_entity (entity);
@@ -19779,9 +19785,23 @@ renew_session_gmp (gvm_connection_t *connection,
   gchar *message;
   gsad_user_t *user = gsad_credentials_get_user (credentials);
 
-  gsad_user_session_renew_timeout (user);
+  if (user)
+    {
+      gsad_user_session_renew_timeout (user);
 
-  message = g_strdup_printf ("%ld", gsad_user_session_get_timeout (user));
+      message = g_strdup_printf ("%ld", gsad_user_session_get_timeout (user));
+    }
+  else
+    {
+      // FIXME this is currently a placeholder for JWT based session timeout
+      time_t current_time = time (NULL);
+      gsad_settings_t *gsad_global_settings =
+        gsad_settings_get_global_settings ();
+      time_t session_timeout =
+        current_time
+        + gsad_settings_get_session_timeout (gsad_global_settings) * 60;
+      message = g_strdup_printf ("%ld", session_timeout);
+    }
 
   html = action_result (connection, credentials, params, response_data,
                         "renew_session", message, NULL, NULL);

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -18815,53 +18815,13 @@ change_password_gmp (gvm_connection_t *connection,
   gchar *passwd_64 = NULL;
   gchar *html = NULL;
   entity_t entity = NULL;
-  gsad_user_t *user = NULL;
-  gmp_authenticate_info_opts_t auth_opts;
-
-  user = gsad_credentials_get_user (credentials);
+  gsad_user_t *user = gsad_credentials_get_user (credentials);
 
   old_passwd = params_value (params, "old_password");
   passwd = params_value (params, "password");
 
   CHECK_VARIABLE_INVALID (passwd, "Change Password")
   CHECK_VARIABLE_INVALID (old_passwd, "Change Password")
-
-  auth_opts = gmp_authenticate_info_opts_defaults;
-  auth_opts.username = gsad_user_get_username (user);
-  auth_opts.password = old_passwd;
-
-  switch (gmp_authenticate_info_ext_c (connection, auth_opts))
-    {
-    case 0:
-      break;
-    case 1:
-      gsad_command_response_data_set_status_code (
-        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "An internal error occurred while changing the password. "
-        "The password was not changed. "
-        "Diagnostics: Manager closed connection during authenticate.",
-        response_data);
-    case 2:
-      gsad_command_response_data_set_status_code (
-        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "You tried to change your password, but the old"
-        " password was not provided or was incorrect. "
-        " Please enter the correct old password to proceed.",
-        response_data);
-    default:
-      gsad_command_response_data_set_status_code (
-        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "An internal error occurred while changing the password. "
-        "The password was not changed. "
-        "Diagnostics: Internal Error.",
-        response_data);
-    }
 
   passwd_64 = g_base64_encode ((guchar *) passwd, strlen (passwd));
 
@@ -18895,7 +18855,7 @@ change_password_gmp (gvm_connection_t *connection,
         response_data);
     }
 
-  if (gmp_success (entity) == 1)
+  if (gmp_success (entity) == 1 && user)
     {
       gsad_user_set_password (user, passwd);
       gsad_session_remove_other_sessions (gsad_user_get_token (user),

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -1103,9 +1103,9 @@ format_file_name (gchar *fname_format, gsad_credentials_t *credentials,
     }
 
   gsad_user_t *user = gsad_credentials_get_user (credentials);
-  ret = gvm_export_file_name (fname_format, gsad_user_get_username (user), type,
-                              uuid, creation_time, modification_time, name,
-                              format_name);
+  ret = gvm_export_file_name (
+    fname_format, user ? gsad_user_get_username (user) : NULL, type, uuid,
+    creation_time, modification_time, name, format_name);
   return ret;
 }
 

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -242,21 +242,6 @@ action_result (gvm_connection_t *, gsad_credentials_t *, params_t *,
 /* Helpers. */
 
 /**
- * @brief Init the GSA GMP library.
- *
- * @param[in]  credentials   Credentials.
- * @param[in]  name          Command name.
- */
-int
-command_enabled (gsad_credentials_t *credentials, const gchar *name)
-{
-  /* TODO Hack.  Fails if command named in summary of another command. */
-  gsad_user_t *user =
-    gsad_credentials_get_user (credentials); // TODO pass gsad_user_t directly
-  return strstr (gsad_user_get_capabilities (user), name) ? 1 : 0;
-}
-
-/**
  *  @brief Structure to search a key by value
  */
 typedef struct
@@ -5322,48 +5307,44 @@ new_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
   free_entity (entity);
 
   /* Get Report Configs. */
-
-  if (command_enabled (credentials, "GET_REPORT_CONFIGS"))
+  ret = gmp (connection, credentials, &response, &entity, response_data,
+             "<get_report_configs filter=\"rows=-1\"/>");
+  switch (ret)
     {
-      ret = gmp (connection, credentials, &response, &entity, response_data,
-                 "<get_report_configs filter=\"rows=-1\"/>");
-      switch (ret)
-        {
-        case 0:
-          break;
-        case 1:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting Report "
-            "Configs for new alert. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        case 2:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting Report "
-            "Configs for new alert. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        default:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting Report "
-            "Configs for new alert. It is unclear whether"
-            " the alert has been saved or not. "
-            "Diagnostics: Internal Error.",
-            response_data);
-        }
-      g_string_append (xml, response);
-      g_free (response);
-      free_entity (entity);
+    case 0:
+      break;
+    case 1:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting Report "
+        "Configs for new alert. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    case 2:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting Report "
+        "Configs for new alert. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    default:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting Report "
+        "Configs for new alert. It is unclear whether"
+        " the alert has been saved or not. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
+  g_string_append (xml, response);
+  g_free (response);
+  free_entity (entity);
 
   /* Get Report Filters. */
 
@@ -6075,179 +6056,159 @@ edit_alert (gvm_connection_t *connection, gsad_credentials_t *credentials,
         response_data);
     }
 
-  if (command_enabled (credentials, "GET_REPORT_FORMATS"))
+  /* Get the report formats. */
+  if (gvm_connection_sendf (connection, "<get_report_formats"
+                                        " filter=\"rows=-1\"/>")
+      == -1)
     {
-      /* Get the report formats. */
-
-      if (gvm_connection_sendf (connection, "<get_report_formats"
-                                            " filter=\"rows=-1\"/>")
-          == -1)
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting report formats. "
-            "The current list of report formats is not available. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        }
-
-      if (read_string_c (connection, &xml))
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting report formats. "
-            "The current list of report formats is not available. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        }
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting report formats. "
+        "The current list of report formats is not available. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
     }
 
-  if (command_enabled (credentials, "GET_REPORT_CONFIGS"))
+  if (read_string_c (connection, &xml))
     {
-      /* Get the report configs. */
-
-      if (gvm_connection_sendf (connection, "<get_report_configs"
-                                            " filter=\"rows=-1\"/>")
-          == -1)
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting report configs. "
-            "The current list of report configs is not available. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        }
-
-      if (read_string_c (connection, &xml))
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting report configs. "
-            "The current list of report configs is not available. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        }
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting report formats. "
+        "The current list of report formats is not available. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
     }
 
-  if (command_enabled (credentials, "GET_FILTERS"))
+  /* Get the report configs. */
+  if (gvm_connection_sendf (connection, "<get_report_configs"
+                                        " filter=\"rows=-1\"/>")
+      == -1)
     {
-      /* Get filters. */
-
-      if (gvm_connection_sendf (connection, "<get_filters filter=\"rows=-1\"/>")
-          == -1)
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting the list "
-            "of filters. "
-            "The current list of filters is not available. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        }
-
-      if (read_string_c (connection, &xml))
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting the list "
-            "of filters. "
-            "The current list of filters is not available. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        }
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting report configs. "
+        "The current list of report configs is not available. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
     }
 
-  if (command_enabled (credentials, "GET_TASKS"))
+  if (read_string_c (connection, &xml))
     {
-      /* Get tasks. */
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting report configs. "
+        "The current list of report configs is not available. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
 
-      if (gvm_connection_sendf (connection,
-                                "<get_tasks"
-                                " schedules_only=\"1\""
-                                " filter=\"owner=any permission=start_task"
-                                "          rows=-1\"/>")
-          == -1)
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting the list "
-            "of tasks. "
-            "The current list of tasks is not available. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        }
+  /* Get filters. */
+  if (gvm_connection_sendf (connection, "<get_filters filter=\"rows=-1\"/>")
+      == -1)
+    {
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the list "
+        "of filters. "
+        "The current list of filters is not available. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
 
-      if (read_string_c (connection, &xml))
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting the list "
-            "of tasks. "
-            "The current list of tasks is not available. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        }
+  if (read_string_c (connection, &xml))
+    {
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the list "
+        "of filters. "
+        "The current list of filters is not available. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
+
+  /* Get tasks. */
+  if (gvm_connection_sendf (connection,
+                            "<get_tasks"
+                            " schedules_only=\"1\""
+                            " filter=\"owner=any permission=start_task"
+                            "          rows=-1\"/>")
+      == -1)
+    {
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the list "
+        "of tasks. "
+        "The current list of tasks is not available. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
+
+  if (read_string_c (connection, &xml))
+    {
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the list "
+        "of tasks. "
+        "The current list of tasks is not available. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
     }
 
   /* Get Credentials. */
-
-  if (command_enabled (credentials, "GET_CREDENTIALS"))
+  if (gvm_connection_sendf (connection, "<get_credentials"
+                                        " filter=\"type=up or type=pw"
+                                        "          owner=any permission=any"
+                                        "          rows=-1\"/>")
+      == -1)
     {
-      if (gvm_connection_sendf (connection, "<get_credentials"
-                                            " filter=\"type=up or type=pw"
-                                            "          owner=any permission=any"
-                                            "          rows=-1\"/>")
-          == -1)
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting the list "
-            "of credentials. "
-            "The current list of tasks is not available. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        }
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the list "
+        "of credentials. "
+        "The current list of tasks is not available. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
 
-      if (read_string_c (connection, &xml))
-        {
-          g_string_free (xml, TRUE);
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred while getting the list "
-            "of credentials. "
-            "The current list of tasks is not available. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        }
+  if (read_string_c (connection, &xml))
+    {
+      g_string_free (xml, TRUE);
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the list "
+        "of credentials. "
+        "The current list of tasks is not available. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
     }
 
   /* Cleanup, and return transformed XML. */
@@ -13287,37 +13248,33 @@ run_wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 }
 
 #define GET_TRASH_RESOURCE(capability, command, name)                       \
-  if (command_enabled (credentials, capability))                            \
+  if (gvm_connection_sendf (connection,                                     \
+                            "<" command " filter=\"rows=-1 sort=name\""     \
+                            " trash=\"1\"/>")                               \
+      == -1)                                                                \
     {                                                                       \
-      if (gvm_connection_sendf (connection,                                 \
-                                "<" command " filter=\"rows=-1 sort=name\"" \
-                                " trash=\"1\"/>")                           \
-          == -1)                                                            \
-        {                                                                   \
-          g_string_free (xml, TRUE);                                        \
-          gsad_command_response_data_set_status_code (                      \
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                 \
-          return gsad_http_create_gsad_message (                            \
-            credentials,                                                    \
-            "An internal error occurred while getting " name                \
-            " list for trash."                                              \
-            "Diagnostics: Failure to send command to"                       \
-            " manager daemon.",                                             \
-            response_data);                                                 \
-        }                                                                   \
+      g_string_free (xml, TRUE);                                            \
+      gsad_command_response_data_set_status_code (                          \
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                     \
+      return gsad_http_create_gsad_message (                                \
+        credentials,                                                        \
+        "An internal error occurred while getting " name " list for trash." \
+        "Diagnostics: Failure to send command to"                           \
+        " manager daemon.",                                                 \
+        response_data);                                                     \
+    }                                                                       \
                                                                             \
-      if (read_string_c (connection, &xml))                                 \
-        {                                                                   \
-          g_string_free (xml, TRUE);                                        \
-          gsad_command_response_data_set_status_code (                      \
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                 \
-          return gsad_http_create_gsad_message (                            \
-            credentials,                                                    \
-            "An internal error occurred while getting " name " list."       \
-            "Diagnostics: Failure to receive response from"                 \
-            " manager daemon.",                                             \
-            response_data);                                                 \
-        }                                                                   \
+  if (read_string_c (connection, &xml))                                     \
+    {                                                                       \
+      g_string_free (xml, TRUE);                                            \
+      gsad_command_response_data_set_status_code (                          \
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);                     \
+      return gsad_http_create_gsad_message (                                \
+        credentials,                                                        \
+        "An internal error occurred while getting " name " list."           \
+        "Diagnostics: Failure to receive response from"                     \
+        " manager daemon.",                                                 \
+        response_data);                                                     \
     }
 
 /**
@@ -16239,49 +16196,48 @@ get_user (gvm_connection_t *connection, gsad_credentials_t *credentials,
   extra = g_string_new ("");
   if (extra_xml)
     g_string_append (extra, extra_xml);
-  if (command_enabled (credentials, "DESCRIBE_AUTH"))
+
+  gchar *response;
+  entity_t entity;
+
+  response = NULL;
+  entity = NULL;
+  switch (gmp (connection, credentials, &response, &entity, response_data,
+               "<describe_auth/>"))
     {
-      gchar *response;
-      entity_t entity;
-
-      response = NULL;
-      entity = NULL;
-      switch (gmp (connection, credentials, &response, &entity, response_data,
-                   "<describe_auth/>"))
-        {
-        case 0:
-          break;
-        case 1:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred getting the auth list. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        case 2:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred getting the auth list. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        default:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred getting the auth list. "
-            "Diagnostics: Internal Error.",
-            response_data);
-        }
-
-      g_string_append (extra, response);
-
-      free_entity (entity);
-      g_free (response);
+    case 0:
+      break;
+    case 1:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred getting the auth list. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    case 2:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred getting the auth list. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    default:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred getting the auth list. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
+
+  g_string_append (extra, response);
+
+  free_entity (entity);
+  g_free (response);
+
   html = get_one (connection, "user", credentials, params, extra->str, NULL,
                   response_data);
   g_string_free (extra, TRUE);
@@ -16523,46 +16479,43 @@ auth_settings_gmp (gvm_connection_t *connection,
   g_string_append (xml, buf);
   g_free (buf);
 
-  if (command_enabled (credentials, "DESCRIBE_AUTH"))
+  gchar *response = NULL;
+  entity_t entity = NULL;
+
+  switch (gmp (connection, credentials, &response, &entity, response_data,
+               "<describe_auth/>"))
     {
-      gchar *response = NULL;
-      entity_t entity = NULL;
-
-      switch (gmp (connection, credentials, &response, &entity, response_data,
-                   "<describe_auth/>"))
-        {
-        case 0:
-          break;
-        case 1:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred getting the auth list. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        case 2:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred getting the auth list. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        default:
-          gsad_command_response_data_set_status_code (
-            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_http_create_gsad_message (
-            credentials,
-            "An internal error occurred getting the auth list. "
-            "Diagnostics: Internal Error.",
-            response_data);
-        }
-
-      g_string_append (xml, response);
-      free_entity (entity);
-      g_free (response);
+    case 0:
+      break;
+    case 1:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred getting the auth list. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    case 2:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred getting the auth list. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    default:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred getting the auth list. "
+        "Diagnostics: Internal Error.",
+        response_data);
     }
+
+  g_string_append (xml, response);
+  free_entity (entity);
+  g_free (response);
 
   g_string_append (xml, "</auth_settings>");
 

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -984,33 +984,37 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
 {
   assert (credentials);
 
+  const gchar *jwt = gsad_credentials_get_jwt (credentials);
   gsad_user_t *user = gsad_credentials_get_user (credentials);
-  const gchar *timezone = gsad_user_get_timezone (user);
-  const gchar *jwt = gsad_user_get_jwt (user);
 
   GString *string = g_string_new ("<envelope>");
 
-  xml_string_append (
-    string,
-    "<client_address>%s</client_address>"
-    "<i18n>%s</i18n>"
-    "<session>%ld</session>"
-    "<timezone>%s</timezone>"
-    "<token>%s</token>"
-    "<version>%s</version>",
-    gsad_user_get_client_address (user), gsad_user_get_language (user),
-    gsad_user_session_get_timeout (user), timezone ? timezone : "",
-    gsad_user_get_token (user), GSAD_VERSION);
+  if (user)
+    {
+      const gchar *timezone = gsad_user_get_timezone (user);
+      const gchar *locale = gsad_user_get_language (user);
+      const gchar *client_address = gsad_user_get_client_address (user);
+      const gchar *token = gsad_user_get_token (user);
+      int timeout = gsad_user_session_get_timeout (user);
+
+      xml_string_append (string,
+                         "<client_address>%s</client_address>"
+                         "<i18n>%s</i18n>"
+                         "<session>%ld</session>"
+                         "<timezone>%s</timezone>"
+                         "<token>%s</token>",
+                         client_address ? client_address : "",
+                         locale ? locale : "", timeout,
+                         timezone ? timezone : "", token ? token : "");
+    }
 
   if (jwt)
     {
-      gchar *jwt_elem = g_markup_printf_escaped ("<jwt>"
-                                                 "%s"
-                                                 "</jwt>",
-                                                 jwt);
-      g_string_append (string, jwt_elem);
-      g_free (jwt_elem);
+      xml_string_append (string, "<jwt>%s</jwt>", jwt);
     }
+
+  xml_string_append (string, "<version>%s</version>", GSAD_VERSION);
+
   g_string_append (string, xml);
   g_string_append (string, "</envelope>");
   g_free (xml);

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -193,7 +193,8 @@ exec_gmp_get (gsad_http_connection_t *connection,
 
 gsad_http_result_t
 exec_gmp_post (gsad_http_connection_t *connection,
-               gsad_connection_info_t *con_info, const gchar *client_address);
+               gsad_connection_info_t *con_info,
+               gsad_credentials_t *credentials);
 
 gchar *
 gsad_http_create_gsad_message (gsad_credentials_t *, const gchar *,

--- a/src/gsad_http.h
+++ b/src/gsad_http.h
@@ -135,6 +135,7 @@ typedef enum gsad_authentication_reason
   BAD_MISSING_COOKIE,
   BAD_MISSING_TOKEN,
   TOO_MANY_USER_SESSIONS,
+  MISSING_CREDENTIALS,
   UNKNOWN_ERROR,
 } gsad_authentication_reason_t;
 

--- a/src/gsad_http_handle_request.c
+++ b/src/gsad_http_handle_request.c
@@ -48,14 +48,26 @@ gsad_http_request_init_handlers (gsad_settings_t *gsad_settings)
 
   gsad_http_handler_t *url_handlers = NULL;
   gsad_http_handler_t *next = NULL;
+  gsad_http_handler_t *gmp_get_handler = NULL;
+
+  gboolean is_jwt_requested = gsad_settings_is_jwt_requested (gsad_settings);
 
   // Create /gmp POST and GET handler chain.
   gsad_http_handler_t *gmp_post_handler =
     gsad_http_handler_new (gsad_http_handle_gmp_post);
-  gsad_http_handler_t *gmp_get_handler =
-    gsad_http_handler_new (gsad_http_handle_setup_user);
-  gsad_http_handler_add_from_func (gmp_get_handler,
-                                   gsad_http_handle_setup_credentials);
+
+  if (!is_jwt_requested)
+    {
+      gmp_get_handler = gsad_http_handler_new (gsad_http_handle_setup_user);
+      gsad_http_handler_add_from_func (gmp_get_handler,
+                                       gsad_http_handle_setup_credentials);
+    }
+  else
+    {
+      gmp_get_handler =
+        gsad_http_handler_new (gsad_http_handle_setup_credentials);
+    }
+
   gsad_http_handler_add_from_func (gmp_get_handler, gsad_http_handle_gmp_get);
   gsad_http_handler_t *gmp_url_handler = gsad_http_url_handler_new (
     "^/gmp$", gsad_http_method_handler_new_with_handlers (gmp_get_handler,

--- a/src/gsad_http_handle_request.c
+++ b/src/gsad_http_handle_request.c
@@ -49,26 +49,39 @@ gsad_http_request_init_handlers (gsad_settings_t *gsad_settings)
   gsad_http_handler_t *url_handlers = NULL;
   gsad_http_handler_t *next = NULL;
   gsad_http_handler_t *gmp_get_handler = NULL;
+  gsad_http_handler_t *gmp_post_handler = NULL;
+  gsad_http_handler_t *system_report_handler = NULL;
 
   gboolean is_jwt_requested = gsad_settings_is_jwt_requested (gsad_settings);
 
-  // Create /gmp POST and GET handler chain.
-  gsad_http_handler_t *gmp_post_handler =
-    gsad_http_handler_new (gsad_http_handle_gmp_post);
-
-  if (!is_jwt_requested)
+  if (is_jwt_requested)
     {
-      gmp_get_handler = gsad_http_handler_new (gsad_http_handle_setup_user);
-      gsad_http_handler_add_from_func (gmp_get_handler,
-                                       gsad_http_handle_setup_credentials);
+      // setup credentials only, no session handling for JWT-based auth
+      gmp_get_handler =
+        gsad_http_handler_new (gsad_http_handle_setup_credentials);
+      gmp_post_handler =
+        gsad_http_handler_new (gsad_http_handle_setup_credentials);
+      system_report_handler =
+        gsad_http_handler_new (gsad_http_handle_setup_credentials);
     }
   else
     {
-      gmp_get_handler =
-        gsad_http_handler_new (gsad_http_handle_setup_credentials);
+      // setup user from session and also the credentials
+      gmp_get_handler = gsad_http_handler_new (gsad_http_handle_setup_user);
+      gsad_http_handler_add_from_func (gmp_get_handler,
+                                       gsad_http_handle_setup_credentials);
+      gmp_post_handler = gsad_http_handler_new (gsad_http_handle_setup_user);
+      gsad_http_handler_add_from_func (gmp_post_handler,
+                                       gsad_http_handle_setup_credentials);
+      system_report_handler =
+        gsad_http_handler_new (gsad_http_handle_setup_user);
+      gsad_http_handler_add_from_func (system_report_handler,
+                                       gsad_http_handle_setup_credentials);
     }
 
+  // Create /gmp POST and GET handler chain.
   gsad_http_handler_add_from_func (gmp_get_handler, gsad_http_handle_gmp_get);
+  gsad_http_handler_add_from_func (gmp_post_handler, gsad_http_handle_gmp_post);
   gsad_http_handler_t *gmp_url_handler = gsad_http_url_handler_new (
     "^/gmp$", gsad_http_method_handler_new_with_handlers (gmp_get_handler,
                                                           gmp_post_handler));
@@ -127,12 +140,7 @@ gsad_http_request_init_handlers (gsad_settings_t *gsad_settings)
     gsad_http_method_handler_new_post_from_func (gsad_http_handle_login));
   next = gsad_http_handler_add (next, login_handler);
 
-  // Create /system_report handler
-  // chain.
-  gsad_http_handler_t *system_report_handler =
-    gsad_http_handler_new (gsad_http_handle_setup_user);
-  gsad_http_handler_add_from_func (system_report_handler,
-                                   gsad_http_handle_setup_credentials);
+  // Create /system_report handler chain.
   gsad_http_handler_add_from_func (system_report_handler,
                                    gsad_http_handle_system_report);
   gsad_http_handler_t *system_report_url_handler = gsad_http_url_handler_new (

--- a/src/gsad_http_handle_request.c
+++ b/src/gsad_http_handle_request.c
@@ -220,6 +220,7 @@ gsad_http_handle_request (void *cls, gsad_http_connection_t *connection,
   gsad_connection_info_t *con_info = *con_cls;
   gsad_http_handler_t *handlers = (gsad_http_handler_t *) cls;
   gboolean new_connection = (con_info == NULL);
+  params_t *params = NULL;
 
   if (handlers == NULL)
     {
@@ -236,7 +237,7 @@ gsad_http_handle_request (void *cls, gsad_http_connection_t *connection,
 
           /* Freed by MHD_OPTION_NOTIFY_COMPLETED callback, free_resources. */
           con_info = gsad_connection_info_new (METHOD_TYPE_GET, url);
-          params_t *params = gsad_connection_info_get_params (con_info);
+          params = gsad_connection_info_get_params (con_info);
           MHD_get_connection_values (connection, MHD_GET_ARGUMENT_KIND,
                                      params_mhd_add, params);
           params_mhd_validate (params);
@@ -288,6 +289,10 @@ gsad_http_handle_request (void *cls, gsad_http_connection_t *connection,
           return MHD_YES;
         }
     }
+
+  /* validate parameters */
+  params = gsad_connection_info_get_params (con_info);
+  params_mhd_validate (params);
 
   g_debug ("Handling %s request for %s", method, url);
 

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -152,21 +152,6 @@ gsad_http_get_jwt_from_connection (gsad_http_connection_t *connection)
 }
 
 /**
- * @brief Internal function for getting the token from the connection.
- *
- * @param[in] connection The HTTP connection for which the request was made
- *
- * @return The token from the connection or NULL if the token is not present or
- * invalid
- */
-static const gchar *
-gsad_http_get_token_from_connection (gsad_http_connection_t *connection)
-{
-  return MHD_lookup_connection_value (connection, MHD_GET_ARGUMENT_KIND,
-                                      "token");
-}
-
-/**
  * @brief Internal function for getting the session cookie from the connection.
  *
  * @param[in] connection The HTTP connection for which the request was made
@@ -193,13 +178,15 @@ gsad_http_get_session_cookie_from_connection (
  */
 static int
 gsad_http_get_user_from_connection (gsad_http_connection_t *connection,
+                                    gsad_connection_info_t *con_info,
                                     gsad_user_t **user)
 {
   const gchar *cookie;
   const gchar *token;
   gchar client_address[INET6_ADDRSTRLEN];
+  params_t *params = gsad_connection_info_get_params (con_info);
 
-  token = gsad_http_get_token_from_connection (connection);
+  token = params_value (params, "token");
   if (token == NULL)
     {
       return USER_BAD_MISSING_TOKEN;
@@ -249,7 +236,7 @@ gsad_http_handle_get_user (gsad_http_handler_t *handler_next,
                            gsad_connection_info_t *con_info, void *data)
 {
   gsad_user_t *user = NULL;
-  gsad_http_get_user_from_connection (connection, &user);
+  gsad_http_get_user_from_connection (connection, con_info, &user);
   return gsad_http_handler_call (handler_next, connection, con_info, user);
 }
 
@@ -285,7 +272,7 @@ gsad_http_handle_setup_user (gsad_http_handler_t *handler_next,
 
   gsad_user_t *user;
 
-  ret = gsad_http_get_user_from_connection (connection, &user);
+  ret = gsad_http_get_user_from_connection (connection, con_info, &user);
 
   if (ret == USER_GMP_DOWN)
     {

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -474,25 +474,10 @@ gsad_http_handle_gmp_post (gsad_http_handler_t *handler_next,
                            gsad_http_connection_t *connection,
                            gsad_connection_info_t *con_info, void *data)
 {
-  const gchar *sid, *accept_language;
-  char client_address[INET6_ADDRSTRLEN];
-
-  sid = gsad_http_get_session_cookie_from_connection (connection);
-
-  if (gvm_validate (http_validator, "token", sid))
-    gsad_connection_info_set_cookie (con_info, NULL);
-  else
-    gsad_connection_info_set_cookie (con_info, sid);
-
-  if (gsad_http_get_client_address (connection, client_address))
-    {
-      gsad_http_send_response_for_content (
-        connection, UTF8_ERROR_PAGE ("'X-Real-IP' header"),
-        MHD_HTTP_BAD_REQUEST, NULL, GSAD_CONTENT_TYPE_TEXT_HTML, NULL, 0);
-      return MHD_YES;
-    }
-
-  return exec_gmp_post (connection, con_info, client_address);
+  gsad_credentials_t *credentials = (gsad_credentials_t *) data;
+  int ret = exec_gmp_post (connection, con_info, credentials);
+  gsad_credentials_free (credentials);
+  return ret;
 }
 
 /**

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -477,16 +477,6 @@ gsad_http_handle_gmp_post (gsad_http_handler_t *handler_next,
   else
     gsad_connection_info_set_cookie (con_info, sid);
 
-  accept_language = MHD_lookup_connection_value (connection, MHD_HEADER_KIND,
-                                                 "Accept-Language");
-  if (accept_language && g_utf8_validate (accept_language, -1, NULL) == FALSE)
-    {
-      gsad_http_send_response_for_content (
-        connection, UTF8_ERROR_PAGE ("'Accept-Language' header"),
-        MHD_HTTP_BAD_REQUEST, NULL, GSAD_CONTENT_TYPE_TEXT_HTML, NULL, 0);
-      return MHD_YES;
-    }
-
   if (gsad_http_get_client_address (connection, client_address))
     {
       gsad_http_send_response_for_content (

--- a/src/gsad_http_handler_functions.c
+++ b/src/gsad_http_handler_functions.c
@@ -348,7 +348,14 @@ gsad_http_handle_setup_credentials (gsad_http_handler_t *handler_next,
   gsad_user_t *user = (gsad_user_t *) data;
   const gchar *jwt = gsad_http_get_jwt_from_connection (connection);
 
+  if (!user && !jwt)
+    {
+      return gsad_http_send_reauthentication (connection, MHD_HTTP_UNAUTHORIZED,
+                                              MISSING_CREDENTIALS);
+    }
+
   gsad_credentials_t *credentials = gsad_credentials_new ();
+
   gsad_credentials_set_user (credentials, user);
   gsad_credentials_set_jwt (credentials, jwt);
   gsad_user_free (user);


### PR DESCRIPTION
## What

Make the User Session optional.

Disclaimer: The session timeout doesn't work correctly with JWT at the moment.

## Why

With this change there are two kinds of authentication:

1. Session based
2. JWT based

The standard and default mode is the session based mode which uses a token and a cookie to create a session and to identify a user. This mode is stateful.

The new mode is JWT based and uses the Authorization header to get the JSON web token. The JWT is passed to GMP without creating a session within gsad. The session is bound to the lifetime of the JWT currently. This mode is stateless.

## References

https://jira.greenbone.net/browse/GEA-1668



