### PR TITLE
Extract the connection watcher into an own module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(
   gsad_base.c
   gsad_command_response_data.c
   gsad_connection_info.c
+  gsad_connection_watcher.c
   gsad_credentials.c
   gsad_env.c
   gsad_gmp.c

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -57,6 +57,7 @@
 /* This must follow the system includes. */
 #include "gsad_args.h"
 #include "gsad_base.h"
+#include "gsad_connection_watcher.h"
 #include "gsad_credentials.h"
 #include "gsad_gmp.h"
 #include "gsad_gmp_auth.h"            /* for authenticate_gmp */
@@ -399,110 +400,6 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
                                     user ? gsad_user_get_cookie (user) : NULL);
 }
 
-/*
- * Connection watcher thread data
- */
-typedef struct
-{
-  int client_socket_fd;
-  gvm_connection_t *gvm_connection;
-  int connection_closed;
-  pthread_mutex_t mutex;
-  gsad_settings_t *gsad_settings;
-} connection_watcher_data_t;
-
-/**
- * @brief  Create a new connection watcher thread data structure.
- *
- * @param[in]  gvm_connection   GVM connection to close if client conn. closes.
- * @param[in]  client_socket_fd File descriptor of client connection to watch.
- *
- * @return  Newly allocated watcher thread data.
- */
-static connection_watcher_data_t *
-connection_watcher_data_new (gvm_connection_t *gvm_connection,
-                             int client_socket_fd,
-                             gsad_settings_t *gsad_settings)
-{
-  connection_watcher_data_t *watcher_data =
-    g_malloc (sizeof (connection_watcher_data_t));
-
-  watcher_data->gvm_connection = gvm_connection;
-  watcher_data->client_socket_fd = client_socket_fd;
-  watcher_data->connection_closed = 0;
-  watcher_data->gsad_settings = gsad_settings;
-  pthread_mutex_init (&(watcher_data->mutex), NULL);
-
-  return watcher_data;
-}
-
-/**
- * @brief   Thread start routine watching the client connection.
- *
- * @param[in] data  The connection data watcher struct.
- *
- * @return  Always NULL.
- */
-static void *
-watch_client_connection (void *data)
-{
-  int active;
-  connection_watcher_data_t *watcher_data;
-
-  pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
-  watcher_data = (connection_watcher_data_t *) data;
-
-  pthread_mutex_lock (&(watcher_data->mutex));
-  active = 1;
-  pthread_mutex_unlock (&(watcher_data->mutex));
-
-  while (active)
-    {
-      pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL);
-      sleep (
-        gsad_settings_get_client_watch_interval (watcher_data->gsad_settings));
-      pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
-
-      pthread_mutex_lock (&(watcher_data->mutex));
-
-      if (watcher_data->connection_closed)
-        {
-          active = 0;
-          pthread_mutex_unlock (&(watcher_data->mutex));
-          continue;
-        }
-      int ret;
-      gchar buf[1];
-      errno = 0;
-      ret = recv (watcher_data->client_socket_fd, buf, 1, MSG_PEEK);
-
-      if (ret >= 0)
-        {
-          if (watcher_data->connection_closed == 0)
-            {
-              watcher_data->connection_closed = 1;
-              active = 0;
-              g_debug ("%s: Client connection closed", __func__);
-
-              if (watcher_data->gvm_connection->tls)
-                {
-                  gvm_connection_t *gvm_conn;
-                  gvm_conn = watcher_data->gvm_connection;
-                  gnutls_bye (gvm_conn->session, GNUTLS_SHUT_RDWR);
-                }
-              else
-                {
-                  gvm_connection_close (watcher_data->gvm_connection);
-                }
-            }
-        }
-
-      pthread_mutex_unlock (&(watcher_data->mutex));
-    }
-
-  return NULL;
-}
-
 #undef ELSE
 
 /**
@@ -669,8 +566,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gsize res_len = 0;
   gsad_http_response_t *response;
   gsad_command_response_data_t *response_data;
-  pthread_t watch_thread;
-  connection_watcher_data_t *watcher_data;
+  gsad_connection_watcher_t *watcher = NULL;
   validator_t validator;
   gchar *encoding;
 
@@ -761,15 +657,9 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       mhd_con_info =
         MHD_get_connection_info (con, MHD_CONNECTION_INFO_CONNECTION_FD);
 
-      watcher_data = connection_watcher_data_new (
-        &connection, mhd_con_info->connect_fd, gsad_global_settings);
-
-      pthread_create (&watch_thread, NULL, watch_client_connection,
-                      watcher_data);
-    }
-  else
-    {
-      watcher_data = NULL;
+      watcher = gsad_connection_watcher_new (gsad_global_settings, &connection,
+                                             mhd_con_info->connect_fd);
+      gsad_connection_watcher_start (watcher);
     }
 
   /* Check cmd and precondition, start respective GMP command(s). */
@@ -1018,19 +908,10 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
     MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_ENCODING,
                              encoding);
 
-  if (watcher_data)
+  if (watcher)
     {
-      pthread_mutex_lock (&(watcher_data->mutex));
-      if (watcher_data->connection_closed == 0
-          || watcher_data->gvm_connection->tls)
-        {
-          gvm_connection_close (watcher_data->gvm_connection);
-        }
-      watcher_data->connection_closed = 1;
-      pthread_mutex_unlock (&(watcher_data->mutex));
-      pthread_cancel (watch_thread);
-      pthread_join (watch_thread, NULL);
-      g_free (watcher_data);
+      gsad_connection_watcher_stop (watcher);
+      gsad_connection_watcher_free (watcher);
     }
   else
     {

--- a/src/gsad_connection_watcher.c
+++ b/src/gsad_connection_watcher.c
@@ -1,0 +1,194 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "gsad_connection_watcher.h"
+
+#include <pthread.h>
+#include <unistd.h> /* for sleep */
+
+struct gsad_connection_watcher_data
+{
+  int client_socket_fd;
+  gvm_connection_t *connection;
+  int connection_closed;
+  pthread_mutex_t mutex;
+  gsad_settings_t *gsad_settings;
+};
+
+typedef struct gsad_connection_watcher_data gsad_connection_watcher_data_t;
+
+struct gsad_connection_watcher
+{
+  pthread_t thread;
+  gsad_connection_watcher_data_t *data;
+};
+
+/**
+ * @brief  Create a new connection watcher thread data structure.
+ *
+ * @param[in]  gsad_settings    Settings to get the watch interval from.
+ * @param[in]  connection       GVM connection to close if client conn. closes.
+ * @param[in]  client_socket_fd File descriptor of client connection to watch.
+ *
+ * @return  Newly allocated watcher thread data.
+ */
+gsad_connection_watcher_data_t *
+gsad_connection_watcher_data_new (gsad_settings_t *gsad_settings,
+                                  gvm_connection_t *connection,
+                                  int client_socket_fd)
+{
+  gsad_connection_watcher_data_t *watcher_data =
+    g_malloc (sizeof (gsad_connection_watcher_data_t));
+
+  watcher_data->connection = connection;
+  watcher_data->client_socket_fd = client_socket_fd;
+  watcher_data->connection_closed = 0;
+  watcher_data->gsad_settings = gsad_settings;
+  pthread_mutex_init (&(watcher_data->mutex), NULL);
+
+  return watcher_data;
+}
+
+/**
+ * @brief   Free the connection watcher thread data structure.
+ *
+ * @param[in]  watcher_data    The connection watcher thread data to free.
+ */
+void
+gsad_connection_watcher_data_free (gsad_connection_watcher_data_t *watcher_data)
+{
+  pthread_mutex_destroy (&(watcher_data->mutex));
+  gsad_settings_free (watcher_data->gsad_settings);
+  g_free (watcher_data);
+}
+
+/**
+ * @brief   Thread start routine watching the client connection.
+ *
+ * @param[in] data  The connection data watcher struct.
+ */
+static void *
+gsad_watch_client_connection (void *data)
+{
+  int active;
+
+  pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
+  gsad_connection_watcher_data_t *watcher_data =
+    (gsad_connection_watcher_data_t *) data;
+
+  pthread_mutex_lock (&(watcher_data->mutex));
+  active = 1;
+  pthread_mutex_unlock (&(watcher_data->mutex));
+
+  while (active)
+    {
+      pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL);
+      sleep (
+        gsad_settings_get_client_watch_interval (watcher_data->gsad_settings));
+      pthread_setcancelstate (PTHREAD_CANCEL_DISABLE, NULL);
+
+      pthread_mutex_lock (&(watcher_data->mutex));
+
+      if (watcher_data->connection_closed)
+        {
+          active = 0;
+          pthread_mutex_unlock (&(watcher_data->mutex));
+          continue;
+        }
+      int ret;
+      gchar buf[1];
+      errno = 0;
+      ret = recv (watcher_data->client_socket_fd, buf, 1, MSG_PEEK);
+
+      if (ret >= 0)
+        {
+          if (watcher_data->connection_closed == 0)
+            {
+              watcher_data->connection_closed = 1;
+              active = 0;
+              g_debug ("Client connection closed");
+
+              if (watcher_data->connection->tls)
+                {
+                  gvm_connection_t *gvm_conn;
+                  gvm_conn = watcher_data->connection;
+                  gnutls_bye (gvm_conn->session, GNUTLS_SHUT_RDWR);
+                }
+              else
+                {
+                  gvm_connection_close (watcher_data->connection);
+                }
+            }
+        }
+
+      pthread_mutex_unlock (&(watcher_data->mutex));
+    }
+
+  return NULL;
+}
+
+/**
+ * @brief   Create a new connection watcher
+ *
+ * @param[in]  gsad_settings    Settings to get the watch interval from.
+ * @param[in]  connection       GVM connection to close if client conn. closes.
+ * @param[in]  client_socket_fd File descriptor of client connection to watch.
+ *
+ * @return  Newly allocated connection watcher.
+ * */
+gsad_connection_watcher_t *
+gsad_connection_watcher_new (gsad_settings_t *gsad_settings,
+                             gvm_connection_t *gvm_connection,
+                             int client_socket_fd)
+{
+  gsad_connection_watcher_t *watcher =
+    g_malloc0 (sizeof (gsad_connection_watcher_t));
+  watcher->data = gsad_connection_watcher_data_new (
+    gsad_settings, gvm_connection, client_socket_fd);
+  return watcher;
+}
+
+void
+gsad_connection_watcher_start (gsad_connection_watcher_t *watcher)
+{
+  pthread_create (&(watcher->thread), NULL, gsad_watch_client_connection,
+                  watcher->data);
+}
+
+/**
+ * @brief   Stop the connection watcher thread and close the connection if not
+ *          already closed.
+ *
+ * @note    This function will block until the thread has stopped.
+ *
+ * @param[in]  watcher The connection watcher to stop.
+ */
+void
+gsad_connection_watcher_stop (gsad_connection_watcher_t *watcher)
+{
+  pthread_mutex_lock (&(watcher->data->mutex));
+  gsad_connection_watcher_data_t *watcher_data = watcher->data;
+  if (watcher_data->connection_closed == 0 || watcher_data->connection->tls)
+    {
+      gvm_connection_close (watcher_data->connection);
+    }
+  watcher_data->connection_closed = 1;
+  g_debug ("Stopping connection watcher thread");
+  pthread_mutex_unlock (&(watcher->data->mutex));
+  pthread_cancel (watcher->thread);
+  pthread_join (watcher->thread, NULL);
+}
+
+/**
+ * @brief   Free the connection watcher.
+ *
+ * @param[in]  watcher The connection watcher to free.
+ */
+void
+gsad_connection_watcher_free (gsad_connection_watcher_t *watcher)
+{
+  gsad_connection_watcher_data_free (watcher->data);
+  g_free (watcher);
+}

--- a/src/gsad_connection_watcher.h
+++ b/src/gsad_connection_watcher.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef _GSAD_CONNECTION_WATCHER_H
+#define _GSAD_CONNECTION_WATCHER_H
+
+#include "gsad_settings.h" /* for gsad_settings_get_client_watch_interval */
+#include "gvm/util/serverutils.h" /* for gvm_connection_t */
+
+typedef struct gsad_connection_watcher gsad_connection_watcher_t;
+
+gsad_connection_watcher_t *
+gsad_connection_watcher_new (gsad_settings_t *, gvm_connection_t *, int);
+
+void
+gsad_connection_watcher_start (gsad_connection_watcher_t *);
+
+void
+gsad_connection_watcher_stop (gsad_connection_watcher_t *);
+
+void
+gsad_connection_watcher_free (gsad_connection_watcher_t *);
+
+#endif /* _GSAD_CONNECTION_WATCHER_H */


### PR DESCRIPTION


## What

Extract the connection watcher into an own module

## Why

Hide internals on how to watch for the connection. Just create, start, stop and free the watcher.


