### PR TITLE
Exec gmp cleanup

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -16798,87 +16798,6 @@ export_users_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
   return export_many (connection, "user", credentials, params, response_data);
 }
 
-char *
-cvss_calculator (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                 params_t *params, gsad_command_response_data_t *response_data)
-{
-  GString *xml;
-  const char *cvss_av, *cvss_au, *cvss_ac, *cvss_c, *cvss_i, *cvss_a;
-  const char *cvss_vector, *name;
-
-  cvss_av = params_value (params, "cvss_av");
-  cvss_au = params_value (params, "cvss_au");
-  cvss_ac = params_value (params, "cvss_ac");
-  cvss_c = params_value (params, "cvss_c");
-  cvss_i = params_value (params, "cvss_i");
-  cvss_a = params_value (params, "cvss_a");
-  cvss_vector = params_value (params, "cvss_vector");
-  name = params_value (params, "name");
-
-  xml = g_string_new ("<cvss_calculator>");
-
-  /* Calculate base score */
-  if (cvss_av && cvss_au && cvss_ac && cvss_c && cvss_i && cvss_a)
-    {
-      char *vector =
-        g_strdup_printf ("AV:%c/AC:%c/Au:%c/C:%c/I:%c/A:%c", *cvss_av, *cvss_ac,
-                         *cvss_au, *cvss_c, *cvss_i, *cvss_a);
-
-      g_string_append_printf (xml,
-                              "<cvss_vector>%s</cvss_vector>"
-                              "<cvss_score>%.1f</cvss_score>",
-                              vector,
-                              get_cvss_score_from_base_metrics (vector));
-
-      g_string_append_printf (xml,
-                              "<cvss_av>%c</cvss_av><cvss_au>%c</cvss_au>"
-                              "<cvss_ac>%c</cvss_ac><cvss_c>%c</cvss_c>"
-                              "<cvss_i>%c</cvss_i><cvss_a>%c</cvss_a>",
-                              *cvss_av, *cvss_au, *cvss_ac, *cvss_c, *cvss_i,
-                              *cvss_a);
-
-      g_free (vector);
-    }
-  else if (cvss_vector)
-    {
-      double cvss_score = get_cvss_score_from_base_metrics (cvss_vector);
-
-      g_string_append_printf (xml,
-                              "<cvss_vector>%s</cvss_vector>"
-                              "<cvss_score>%.1f</cvss_score>",
-                              cvss_vector, cvss_score);
-
-      if (cvss_score != -1.0)
-        {
-          cvss_av = strstr (cvss_vector, "AV:");
-          cvss_ac = strstr (cvss_vector, "/AC:");
-          cvss_au = strstr (cvss_vector, "/Au:");
-          if (cvss_au == NULL)
-            cvss_au = strstr (cvss_vector, "/AU:");
-          cvss_c = strstr (cvss_vector, "/C:");
-          cvss_i = strstr (cvss_vector, "/I:");
-          cvss_a = strstr (cvss_vector, "/A:");
-
-          if (cvss_av && cvss_ac && cvss_au && cvss_c && cvss_i && cvss_a)
-            g_string_append_printf (xml,
-                                    "<cvss_av>%c</cvss_av><cvss_ac>%c</cvss_ac>"
-                                    "<cvss_au>%c</cvss_au><cvss_c>%c</cvss_c>"
-                                    "<cvss_i>%c</cvss_i><cvss_a>%c</cvss_a>",
-                                    *(cvss_av + 3), *(cvss_ac + 4),
-                                    *(cvss_au + 4), *(cvss_c + 3),
-                                    *(cvss_i + 3), *(cvss_a + 3));
-        }
-    }
-  else if (name && !strcmp ("vector", name))
-    {
-      g_string_append_printf (xml, "<cvss_score>%.1f</cvss_score>", -1.0);
-    }
-
-  g_string_append (xml, "</cvss_calculator>");
-  return envelope_gmp (connection, credentials, params,
-                       g_string_free (xml, FALSE), response_data);
-}
-
 /**
  * @brief Generate AUTH_CONF_SETTING element for save_auth_gmp.
  */
@@ -20806,11 +20725,6 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
                                              mhd_con_info->connect_fd);
       gsad_connection_watcher_start (watcher);
     }
-
-  /* Check cmd and precondition, start respective GMP command(s). */
-
-  if (!strcmp (cmd, "cvss_calculator"))
-    res = cvss_calculator (&connection, credentials, params, response_data);
 
   ELSE (auth_settings)
   ELSE (edit_alert)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20783,40 +20783,6 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_agent_installer_file)
   ELSE (get_asset)
   ELSE (get_assets)
-
-  else if (!strcmp (cmd, "download_ssl_cert"))
-  {
-    gsad_command_response_data_set_content_type (response_data,
-                                                 GSAD_CONTENT_TYPE_APP_KEY);
-    gsad_command_response_data_set_content_disposition (
-      response_data, g_strdup_printf ("attachment; filename=ssl-cert-%s.pem",
-                                      params_value (params, "name")));
-
-    res = download_ssl_cert (&connection, credentials, params, response_data);
-  }
-
-  else if (!strcmp (cmd, "download_ca_pub"))
-  {
-    gsad_command_response_data_set_content_type (response_data,
-                                                 GSAD_CONTENT_TYPE_APP_KEY);
-    gsad_command_response_data_set_content_disposition (
-      response_data,
-      g_strdup_printf ("attachment; filename=scanner-ca-pub-%s.pem",
-                       params_value (params, "scanner_id")));
-    res = download_ca_pub (&connection, credentials, params, response_data);
-  }
-
-  else if (!strcmp (cmd, "download_key_pub"))
-  {
-    gsad_command_response_data_set_content_type (response_data,
-                                                 GSAD_CONTENT_TYPE_APP_KEY);
-    gsad_command_response_data_set_content_disposition (
-      response_data,
-      g_strdup_printf ("attachment; filename=scanner-key-pub-%s.pem",
-                       params_value (params, "scanner_id")));
-    res = download_key_pub (&connection, credentials, params, response_data);
-  }
-
   ELSE (get_aggregate)
   ELSE (get_alert)
   ELSE (get_alerts)
@@ -20913,6 +20879,39 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (ping)
   ELSE (wizard)
   ELSE (wizard_get)
+
+  else if (!strcmp (cmd, "download_ssl_cert"))
+  {
+    gsad_command_response_data_set_content_type (response_data,
+                                                 GSAD_CONTENT_TYPE_APP_KEY);
+    gsad_command_response_data_set_content_disposition (
+      response_data, g_strdup_printf ("attachment; filename=ssl-cert-%s.pem",
+                                      params_value (params, "name")));
+
+    res = download_ssl_cert (&connection, credentials, params, response_data);
+  }
+
+  else if (!strcmp (cmd, "download_ca_pub"))
+  {
+    gsad_command_response_data_set_content_type (response_data,
+                                                 GSAD_CONTENT_TYPE_APP_KEY);
+    gsad_command_response_data_set_content_disposition (
+      response_data,
+      g_strdup_printf ("attachment; filename=scanner-ca-pub-%s.pem",
+                       params_value (params, "scanner_id")));
+    res = download_ca_pub (&connection, credentials, params, response_data);
+  }
+
+  else if (!strcmp (cmd, "download_key_pub"))
+  {
+    gsad_command_response_data_set_content_type (response_data,
+                                                 GSAD_CONTENT_TYPE_APP_KEY);
+    gsad_command_response_data_set_content_disposition (
+      response_data,
+      g_strdup_printf ("attachment; filename=scanner-key-pub-%s.pem",
+                       params_value (params, "scanner_id")));
+    res = download_key_pub (&connection, credentials, params, response_data);
+  }
 
   else
   {

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -228,10 +228,6 @@ static char *
 wizard (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
         gsad_command_response_data_t *);
 
-static char *
-wizard_get (gvm_connection_t *, gsad_credentials_t *, params_t *, const char *,
-            gsad_command_response_data_t *);
-
 static int
 gmp_success (entity_t entity);
 
@@ -17283,133 +17279,6 @@ wizard_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
 }
 
 /**
- * @brief Returns a wizard_get page.
- *
- * @param[in]  connection     Connection to manager.
- * @param[in]  credentials    Credentials of user issuing the action.
- * @param[in]  params         Request parameters.
- * @param[in]  extra_xml      Extra XML to insert inside page element.
- * @param[out] response_data  Extra data return for the HTTP response.
- *
- * @return Enveloped XML object.
- */
-char *
-wizard_get (gvm_connection_t *connection, gsad_credentials_t *credentials,
-            params_t *params, const char *extra_xml,
-            gsad_command_response_data_t *response_data)
-{
-  const char *name;
-  int ret;
-  GString *run;
-  param_t *param;
-  gchar *param_name, *response;
-  params_iterator_t iter;
-  params_t *wizard_params;
-  entity_t entity;
-  gchar *wizard_xml;
-
-  /* The naming is a bit subtle here, because the HTTP request
-   * parameters are called "param"s and so are the GMP wizard
-   * parameters. */
-
-  name = params_value (params, "get_name");
-  if (name == NULL)
-    {
-      gsad_command_response_data_set_status_code (response_data,
-                                                  MHD_HTTP_BAD_REQUEST);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "An internal error occurred while trying to start a wizard. "
-        "Diagnostics: Required parameter 'get_name' was NULL.",
-        response_data);
-    }
-
-  run = g_string_new ("<run_wizard read_only=\"1\">");
-
-  g_string_append_printf (run,
-                          "<name>%s</name>"
-                          "<params>",
-                          name);
-
-  wizard_params = params_values (params, "event_data:");
-  if (wizard_params)
-    {
-      params_iterator_init (&iter, wizard_params);
-      while (params_iterator_next (&iter, &param_name, &param))
-        xml_string_append (run,
-                           "<param>"
-                           "<name>%s</name>"
-                           "<value>%s</value>"
-                           "</param>",
-                           param_name, param->value);
-    }
-
-  g_string_append (run, "</params></run_wizard>");
-
-  response = NULL;
-  entity = NULL;
-  ret =
-    gmp (connection, credentials, &response, &entity, response_data, run->str);
-  g_string_free (run, TRUE);
-  switch (ret)
-    {
-    case 0:
-      break;
-    case 1:
-      gsad_command_response_data_set_status_code (
-        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "An internal error occurred while running a wizard. "
-        "The wizard did not start. "
-        "Diagnostics: Failure to send command to manager daemon.",
-        response_data);
-    case 2:
-      gsad_command_response_data_set_status_code (
-        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "An internal error occurred while running a wizard. "
-        "It is unclear whether the wizard started or not. "
-        "Diagnostics: Failure to receive response from manager daemon.",
-        response_data);
-    default:
-      gsad_command_response_data_set_status_code (
-        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_http_create_gsad_message (
-        credentials,
-        "An internal error occurred while running a wizard. "
-        "It is unclear whether the wizard started or not. "
-        "Diagnostics: Internal Error.",
-        response_data);
-    }
-
-  wizard_xml = g_strdup_printf ("<wizard><%s/>%s%s</wizard>", name,
-                                extra_xml ? extra_xml : "", response);
-  g_free (response);
-
-  return envelope_gmp (connection, credentials, params, wizard_xml,
-                       response_data);
-}
-
-/**
- * @brief Returns a wizard_get page.
- *
- * @param[in]  connection     Connection to manager.
- * @param[in]  credentials    Credentials of user issuing the action.
- * @param[in]  params         Request parameters.
- * @param[out] response_data  Extra data return for the HTTP response.
- *
- * @return Enveloped XML object.
- */
-char *
-wizard_get_gmp (gvm_connection_t *connection, gsad_credentials_t *credentials,
-                params_t *params, gsad_command_response_data_t *response_data)
-{
-  return wizard_get (connection, credentials, params, NULL, response_data);
-}
-
-/**
  * @brief Delete multiple resources, get next page, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
@@ -20878,7 +20747,6 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (new_alert)
   ELSE (ping)
   ELSE (wizard)
-  ELSE (wizard_get)
 
   else if (!strcmp (cmd, "download_ssl_cert"))
   {

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20595,6 +20595,9 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       gsad_connection_watcher_start (watcher);
     }
 
+  if (0)
+    {
+    }
   ELSE (auth_settings)
   ELSE (edit_alert)
   ELSE (edit_config_family)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20498,13 +20498,11 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gchar *res = NULL, *comp = NULL;
   gsize res_len = 0;
   gsad_http_response_t *response;
-  gsad_command_response_data_t *response_data;
+  gsad_command_response_data_t *response_data =
+    gsad_command_response_data_new ();
   gsad_connection_watcher_t *watcher = NULL;
-  validator_t validator;
+  validator_t validator = gsad_get_validator ();
   gchar *encoding;
-
-  validator = gsad_get_validator ();
-  response_data = gsad_command_response_data_new ();
 
   cmd = params_value (params, "cmd");
 
@@ -20873,11 +20871,13 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   gsad_command_response_data_t *response_data =
     gsad_command_response_data_new ();
   gsad_user_t *user = gsad_credentials_get_user (credentials);
-
+  validator_t validator = gsad_get_validator ();
   params_t *params = gsad_connection_info_get_params (con_info);
-  params_mhd_validate (params);
 
   cmd = params_value (params, "cmd");
+
+  if (gvm_validate (validator, "cmd", cmd))
+    cmd = NULL;
 
   if (!cmd)
     {

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -680,10 +680,6 @@ wizard_get_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                 gsad_command_response_data_t *);
 
 char *
-cvss_calculator (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                 gsad_command_response_data_t *);
-
-char *
 get_trash_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,
                gsad_command_response_data_t *);
 char *

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -675,9 +675,6 @@ run_wizard_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
 char *
 wizard_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
             gsad_command_response_data_t *);
-char *
-wizard_get_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
-                gsad_command_response_data_t *);
 
 char *
 get_trash_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *params,


### PR DESCRIPTION
## What

Cleanup exec_gmp functions for handling `/gmp` GET and POST requests

The following unused endpoints are removed:

* `/gmp?cmd=cvss_calculator`
* `/gmp?cmd=wizard_get`

## Why

Both endpoints are not used in GSA anymore.

Change `exec_gmp_post` and `exec_gmp_get` functions to be similar as possible.


