### PR TITLE
Improve getting host from params for override and note

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -10877,22 +10877,16 @@ get_hosts_from_params (params_t *params)
   if (params_valid (params, "hosts"))
     {
       hosts = params_value (params, "hosts");
-      if (strcmp (hosts, "--") == 0)
+      if (str_equal (hosts, "--"))
         {
           if (params_valid (params, "hosts_manual"))
             hosts = params_value (params, "hosts_manual");
-          else if (params_given (params, "hosts_manual")
-                   && strcmp (params_original_value (params, "hosts_manual"),
-                              ""))
-            hosts = NULL;
           else
-            hosts = "";
+            hosts = NULL;
         }
     }
-  else if (strcmp (params_original_value (params, "hosts"), ""))
-    hosts = NULL;
   else
-    hosts = "";
+    hosts = NULL;
 
   return hosts;
 }


### PR DESCRIPTION




## What

Improve getting host from params for override and note

## Why

Ensure we get the desired host data from the params when creating or updating overrides and notes. This is a bug in gsad 26.0.0 but already seems to be fixed in main due to refactoring of the exec_gmp function. Nevertheless be safe and ensure we get the expected host data without ever crashing.
## References

https://jira.greenbone.net/browse/GEA-1808
#411 


