### PR TITLE
Add/web application target cmds

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20261,6 +20261,205 @@ delete_web_application_target_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Modify a web application target, get all targets, envelope the result.
+ *
+ * @param[in]  connection     Connection to manager.
+ * @param[in]  credentials    Username and password for authentication.
+ * @param[in]  params         Request parameters.
+ * @param[out] response_data  Extra data return for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+save_web_application_target_gmp (gvm_connection_t *connection,
+                                 gsad_credentials_t *credentials,
+                                 params_t *params,
+                                 gsad_command_response_data_t *response_data)
+{
+  entity_t entity;
+  const char *name, *comment, *urls, *exclude_urls = NULL;
+  const char *credential, *target_source, *file;
+  const char *target_exclude_source = NULL, *exclude_file = NULL;
+  const char *web_application_target_id, *in_use;
+  gchar *xml;
+  GString *command;
+  int ret;
+
+  name = params_value (params, "name");
+  comment = params_value (params, "comment");
+  in_use = params_value (params, "in_use");
+  web_application_target_id =
+    params_value (params, "web_application_target_id");
+
+  CHECK_VARIABLE_INVALID (name, "Save Web Application Target");
+  CHECK_VARIABLE_INVALID (web_application_target_id,
+                          "Save Web Application Target");
+  CHECK_VARIABLE_INVALID (in_use, "Save Web Application Target");
+  CHECK_VARIABLE_INVALID (comment, "Save Web Application Target");
+
+  if (strcmp (in_use, "1") == 0)
+    {
+      /* Target is in use. Modify fewer fields. */
+
+      command = g_string_new ("");
+      xml_string_append (
+        command,
+        "<modify_web_application_target web_application_target_id=\"%s\">"
+        "<name>%s</name>"
+        "<comment>%s</comment>"
+        "</modify_web_application_target>",
+        web_application_target_id, name, comment);
+
+      entity = NULL;
+      ret = gmp (connection, credentials, NULL, &entity, response_data,
+                 command->str);
+      g_string_free (command, TRUE);
+
+      switch (ret)
+        {
+        case 0:
+          break;
+        case 1:
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_http_create_gsad_message (
+            credentials,
+            "An internal error occurred while saving a web application "
+            "target. The target remains the same. "
+            "Diagnostics: Failure to send command to manager daemon.",
+            response_data);
+        case 2:
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_http_create_gsad_message (
+            credentials,
+            "An internal error occurred while saving a web application "
+            "target. It is unclear whether the target has been saved or not. "
+            "Diagnostics: Failure to receive response from manager daemon.",
+            response_data);
+        default:
+          gsad_command_response_data_set_status_code (
+            response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+          return gsad_http_create_gsad_message (
+            credentials,
+            "An internal error occurred while saving a web application "
+            "target. It is unclear whether the target has been saved or not. "
+            "Diagnostics: Internal Error.",
+            response_data);
+        }
+
+      xml = response_from_entity (connection, credentials, params, entity,
+                                  "Save Web Application Target", response_data);
+
+      free_entity (entity);
+      return xml;
+    }
+
+  file = params_value (params, "file");
+  urls = params_value (params, "urls");
+  target_source = params_value (params, "target_source");
+  credential = params_value (params, "credential_id");
+
+  CHECK_VARIABLE_INVALID (target_source, "Save Web Application Target");
+
+  if (strcmp (target_source, "manual") == 0)
+    CHECK_VARIABLE_INVALID (urls, "Save Web Application Target");
+
+  if (strcmp (target_source, "file") == 0)
+    CHECK_VARIABLE_INVALID (file, "Save Web Application Target");
+
+  if (params_given (params, "target_exclude_source"))
+    {
+      target_exclude_source = params_value (params, "target_exclude_source");
+      CHECK_VARIABLE_INVALID (target_exclude_source,
+                              "Save Web Application Target");
+
+      exclude_urls = params_value (params, "exclude_urls");
+      exclude_file = params_value (params, "exclude_file");
+
+      if (str_equal (target_exclude_source, "manual")
+          && params_given (params, "exclude_urls"))
+        {
+          CHECK_VARIABLE_INVALID (exclude_urls, "Save Web Application Target");
+        }
+      else if (str_equal (target_exclude_source, "file")
+               && params_given (params, "exclude_file"))
+        {
+          CHECK_VARIABLE_INVALID (exclude_file, "Save Web Application Target");
+        }
+    }
+
+  if (params_given (params, "credential_id"))
+    CHECK_VARIABLE_INVALID (credential, "Save Web Application Target");
+
+  gchar *credential_element = NULL;
+  if (credential)
+    credential_element =
+      g_strdup_printf ("<credential id=\"%s\"/>", credential);
+
+  command = g_string_new ("");
+  xml_string_append (
+    command,
+    "<modify_web_application_target web_application_target_id=\"%s\">"
+    "<name>%s</name>"
+    "<comment>%s</comment>"
+    "<urls>%s</urls>"
+    "<exclude_urls>%s</exclude_urls>",
+    web_application_target_id,
+    name,
+    comment,
+    (strcmp (target_source, "file") == 0) ? file : urls,
+    target_exclude_source
+      ? (strcmp (target_exclude_source, "file") == 0
+           ? exclude_file ?: ""
+           : exclude_urls ?: "")
+      : "");
+
+  g_string_append_printf (command,
+                          "%s"
+                          "</modify_web_application_target>",
+                          credential_element ?: "");
+
+  g_free (credential_element);
+
+  /* Modify the target. */
+
+  ret = gvm_connection_sendf (connection, "%s", command->str);
+  g_string_free (command, TRUE);
+
+  if (ret == -1)
+    {
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while modifying a web application target. "
+        "No target was modified. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
+
+  entity = NULL;
+  if (read_entity_c (connection, &entity))
+    {
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while modifying a web application target. "
+        "It is unclear whether the target has been modified or not. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
+
+  xml = response_from_entity (connection, credentials, params, entity,
+                              "Save Web Application Target", response_data);
+
+  free_entity (entity);
+  return xml;
+}
+
+/**
  * @brief Get assets, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
@@ -21297,6 +21496,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (save_import_task)
   ELSE (save_tls_certificate)
   ELSE (save_user)
+  ELSE (save_web_application_target)
   ELSE (start_task)
   ELSE (stop_task)
   ELSE (sync_agents)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -19976,6 +19976,156 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Create a web application target, get all targets, envelope the result.
+ *
+ * @param[in]  connection     Connection to manager.
+ * @param[in]  credentials    Username and password for authentication.
+ * @param[in]  params         Request parameters.
+ * @param[out] response_data  Extra data return for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+create_web_application_target_gmp (gvm_connection_t *connection,
+                                   gsad_credentials_t *credentials,
+                                   params_t *params,
+                                   gsad_command_response_data_t *response_data)
+{
+  int ret;
+  gchar *xml;
+  const char *name, *urls, *comment;
+  const char *credential, *target_source, *file;
+  const char *exclude_urls, *target_exclude_source, *exclude_file;
+  gchar *credential_element;
+  gchar *comment_element = NULL;
+  entity_t entity;
+  GString *command;
+
+  name = params_value (params, "name");
+  urls = params_value (params, "urls");
+  exclude_urls = params_value (params, "exclude_urls");
+  comment = params_value (params, "comment");
+  credential = params_value (params, "credential_id");
+  target_source = params_value (params, "target_source");
+  target_exclude_source = params_value (params, "target_exclude_source");
+  file = params_value (params, "file");
+  exclude_file = params_value (params, "exclude_file");
+
+  CHECK_VARIABLE_INVALID (name, "Create Web Application Target");
+  CHECK_VARIABLE_INVALID (target_source, "Create Web Application Target");
+
+  if (strcmp (target_source, "manual") == 0)
+    CHECK_VARIABLE_INVALID (urls, "Create Web Application Target");
+
+  if (strcmp (target_source, "file") == 0)
+    CHECK_VARIABLE_INVALID (file, "Create Web Application Target");
+
+  if (params_given (params, "target_exclude_source"))
+    {
+      CHECK_VARIABLE_INVALID (target_exclude_source,
+                              "Create Web Application Target");
+
+      if (str_equal (target_exclude_source, "manual")
+          && params_given (params, "exclude_urls"))
+        CHECK_VARIABLE_INVALID (exclude_urls, "Create Web Application Target");
+
+      if (str_equal (target_exclude_source, "file")
+          && params_given (params, "exclude_file"))
+        CHECK_VARIABLE_INVALID (exclude_file, "Create Web Application Target");
+    }
+
+  if (params_given (params, "comment"))
+    CHECK_VARIABLE_INVALID (comment, "Create Web Application Target");
+
+  if (params_given (params, "credential_id"))
+    CHECK_VARIABLE_INVALID (credential, "Create Web Application Target");
+
+  comment_element = NULL;
+  if (comment)
+    comment_element =
+      g_markup_printf_escaped ("<comment>%s</comment>", comment);
+
+  credential_element = NULL;
+  if (credential && !str_equal (credential, ""))
+    credential_element =
+      g_strdup_printf ("<credential id=\"%s\"/>", credential);
+
+  /* Create the web application target. */
+
+  command = g_string_new ("");
+
+  xml_string_append (
+    command,
+    "<create_web_application_target>"
+    "<name>%s</name>"
+    "<urls>%s</urls>"
+    "<exclude_urls>%s</exclude_urls>",
+    name,
+    str_equal (target_source, "file") ? file : urls,
+    target_exclude_source
+      ? (str_equal (target_exclude_source, "file")
+         ? exclude_file ?: ""
+         : exclude_urls ?: "")
+      : "");
+
+  g_string_append_printf (command,
+                          "%s%s"
+                          "</create_web_application_target>",
+                          comment_element ?: "", credential_element ?: "");
+
+  g_free (comment_element);
+  g_free (credential_element);
+
+  ret =
+    gmp (connection, credentials, NULL, &entity, response_data, command->str);
+
+  g_string_free (command, TRUE);
+
+  switch (ret)
+    {
+    case 0:
+      break;
+    case 1:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while creating a new web application "
+        "target. No new target was created. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    case 2:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while creating a new web application "
+        "target. It is unclear whether the target has been created or not. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    default:
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while creating a new web application "
+        "target. It is unclear whether the target has been created or not. "
+        "Diagnostics: Internal Error.",
+        response_data);
+    }
+
+  if (entity_attribute (entity, "id"))
+    params_add (params, "web_application_target_id",
+                entity_attribute (entity, "id"));
+
+  xml = response_from_entity (connection, credentials, params, entity,
+                              "Create Web Application Target", response_data);
+
+  free_entity (entity);
+  return xml;
+}
+
+/**
  * @brief Get assets, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
@@ -20934,6 +21084,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (create_role)
   ELSE (create_agent_group)
   ELSE (create_agent_group_task)
+  ELSE (create_web_application_target)
   ELSE (delete_agent_group)
   ELSE (delete_asset)
   ELSE (delete_alert)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -13833,6 +13833,33 @@ get_trash_agent_group_gmp (gvm_connection_t *connection,
                        g_string_free (xml, FALSE), response_data);
 }
 
+/**
+ * @brief Setup trash page XML, envelope the result.
+ *
+ * @param[in]  connection     Connection to manager.
+ * @param[in]  credentials    Username and password for authentication.
+ * @param[in]  params         Request parameters.
+ * @param[out] response_data  Extra data return for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_trash_web_application_targets_gmp (
+  gvm_connection_t *connection, gsad_credentials_t *credentials,
+  params_t *params, gsad_command_response_data_t *response_data)
+{
+  GString *xml = g_string_new ("<get_trash>");
+
+  GET_TRASH_RESOURCE ("GET_WEB_APPLICATION_TARGETS",
+                      "get_web_application_targets", "web_application_targets");
+
+  /* Cleanup, and return transformed XML. */
+
+  g_string_append (xml, "</get_trash>");
+  return envelope_gmp (connection, credentials, params,
+                       g_string_free (xml, FALSE), response_data);
+}
+
 #undef GET_TRASH_RESOURCE
 
 /* Groups. */
@@ -20944,6 +20971,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_trash_targets)
   ELSE (get_trash_tasks)
   ELSE (get_trash_tickets)
+  ELSE (get_trash_web_application_targets)
   ELSE (get_user)
   ELSE (get_users)
   ELSE (get_vulns)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -19976,6 +19976,52 @@ save_oci_image_target_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Get one web application target, envelope the result.
+ *
+ * @param[in]  connection     Connection to manager.
+ * @param[in]  credentials    Username and password for authentication.
+ * @param[in]  params         Request parameters.
+ * @param[out] response_data  Extra data return for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_web_application_target_gmp (gvm_connection_t *connection,
+                                gsad_credentials_t *credentials,
+                                params_t *params,
+                                gsad_command_response_data_t *response_data)
+{
+  gmp_arguments_t *arguments;
+
+  arguments = gmp_arguments_new ();
+
+  gmp_arguments_add (arguments, "tasks", "1");
+
+  return get_one (connection, "web_application_target", credentials, params,
+                  NULL, arguments, response_data);
+}
+
+/**
+ * @brief Get all web application targets, envelope the result.
+ *
+ * @param[in]  connection     Connection to manager.
+ * @param[in]  credentials    Username and password for authentication.
+ * @param[in]  params         Request parameters.
+ * @param[out] response_data  Extra data return for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_web_application_targets_gmp (gvm_connection_t *connection,
+                                 gsad_credentials_t *credentials,
+                                 params_t *params,
+                                 gsad_command_response_data_t *response_data)
+{
+  return get_many (connection, "web_application_targets", credentials, params,
+                   NULL, response_data);
+}
+
+/**
  * @brief Create a web application target, get all targets, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
@@ -20837,6 +20883,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_user)
   ELSE (get_users)
   ELSE (get_vulns)
+  ELSE (get_web_application_target)
+  ELSE (get_web_application_targets)
   ELSE (new_alert)
   ELSE (ping)
   ELSE (wizard)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20214,6 +20214,26 @@ create_web_application_target_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Delete a web application target, get all targets, envelope the result.
+ *
+ * @param[in]  connection     Connection to manager.
+ * @param[in]  credentials    Username and password for authentication.
+ * @param[in]  params         Request parameters.
+ * @param[out] response_data  Extra data return for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+delete_web_application_target_gmp (gvm_connection_t *connection,
+                                   gsad_credentials_t *credentials,
+                                   params_t *params,
+                                   gsad_command_response_data_t *response_data)
+{
+  return move_resource_to_trash (connection, "web_application_target",
+                                 credentials, params, response_data);
+}
+
+/**
  * @brief Get assets, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
@@ -21203,6 +21223,7 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (delete_ticket)
   ELSE (delete_tls_certificate)
   ELSE (delete_user)
+  ELSE (delete_web_application_target)
   ELSE (empty_trashcan)
   ELSE (import_config)
   ELSE (import_port_list)

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20022,6 +20022,48 @@ get_web_application_targets_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Export a web application target.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Username and password for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data return for the HTTP response.
+ *
+ * @return Web application target XML on success.  Enveloped XML
+ *         on error.
+ */
+char *
+export_web_application_target_gmp (gvm_connection_t *connection,
+                                   gsad_credentials_t *credentials,
+                                   params_t *params,
+                                   gsad_command_response_data_t *response_data)
+{
+  return export_resource (connection, "web_application_target", credentials,
+                          params, response_data);
+}
+
+/**
+ * @brief Export a list of web application targets.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Username and password for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data return for the HTTP response.
+ *
+ * @return Web application targets XML on success.  Enveloped XML
+ *         on error.
+ */
+char *
+export_web_application_targets_gmp (gvm_connection_t *connection,
+                                    gsad_credentials_t *credentials,
+                                    params_t *params,
+                                    gsad_command_response_data_t *response_data)
+{
+  return export_many (connection, "web_application_target", credentials, params,
+                      response_data);
+}
+
+/**
  * @brief Create a web application target, get all targets, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
@@ -20784,6 +20826,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (export_tasks)
   ELSE (export_user)
   ELSE (export_users)
+  ELSE (export_web_application_target)
+  ELSE (export_web_application_targets)
   ELSE (get_agent_installer_instruction)
   ELSE (get_agent)
   ELSE (get_agents)

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -746,8 +746,14 @@ get_trash_agent_group_gmp (gvm_connection_t *connection,
                            gsad_command_response_data_t *response_data);
 
 char *
-get_trash_oci_image_targets (gvm_connection_t *, gsad_credentials_t *,
-                             params_t *params, gsad_command_response_data_t *);
+get_trash_oci_image_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                 params_t *params,
+                                 gsad_command_response_data_t *);
+
+char *
+get_trash_web_application_targets_gmp (
+  gvm_connection_t *connection, gsad_credentials_t *credentials,
+  params_t *params, gsad_command_response_data_t *response_data);
 
 char *
 restore_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -939,6 +939,13 @@ save_oci_image_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                          gsad_command_response_data_t *);
 
 char *
+get_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                params_t *, gsad_command_response_data_t *);
+char *
+get_web_application_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                 params_t *, gsad_command_response_data_t *);
+
+char *
 create_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
                                    params_t *, gsad_command_response_data_t *);
 

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -957,6 +957,10 @@ create_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
                                    params_t *, gsad_command_response_data_t *);
 
 char *
+delete_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                   params_t *, gsad_command_response_data_t *);
+
+char *
 renew_session_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                    gsad_command_response_data_t *);
 char *

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -939,6 +939,10 @@ save_oci_image_task_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                          gsad_command_response_data_t *);
 
 char *
+create_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                   params_t *, gsad_command_response_data_t *);
+
+char *
 renew_session_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                    gsad_command_response_data_t *);
 char *

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -967,6 +967,10 @@ delete_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
                                    params_t *, gsad_command_response_data_t *);
 
 char *
+save_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                 params_t *, gsad_command_response_data_t *);
+
+char *
 renew_session_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                    gsad_command_response_data_t *);
 char *

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -946,6 +946,13 @@ get_web_application_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
                                  params_t *, gsad_command_response_data_t *);
 
 char *
+export_web_application_targets_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                    params_t *, gsad_command_response_data_t *);
+char *
+export_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
+                                   params_t *, gsad_command_response_data_t *);
+
+char *
 create_web_application_target_gmp (gvm_connection_t *, gsad_credentials_t *,
                                    params_t *, gsad_command_response_data_t *);
 

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -289,6 +289,7 @@ gsad_init_validator ()
                      "|(save_ticket)"
                      "|(save_tls_certificate)"
                      "|(save_user)"
+                     "|(save_web_application_target)"
                      "|(start_task)"
                      "|(stop_task)"
                      "|(sync_agents)"

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -234,6 +234,7 @@ gsad_init_validator ()
                      "|(get_trash_targets)"
                      "|(get_trash_tasks)"
                      "|(get_trash_tickets)"
+                     "|(get_trash_web_application_targets)"
                      "|(get_user)"
                      "|(get_users)"
                      "|(get_vulns)"

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -53,6 +53,7 @@ gsad_init_validator ()
                      "|(create_agent_group)"
                      "|(create_agent_group_task)"
                      "|(create_oci_image_task)"
+                     "|(create_web_application_target)"
                      "|(cvss_calculator)"
                      "|(delete_agent)"
                      "|(delete_agent_group)"
@@ -444,6 +445,8 @@ gsad_init_validator ()
   gvm_validator_add (validator, "number", "^ *[0-9]+ *$");
   gvm_validator_add (validator, "image_references",
                      "^[-_@[:alnum:],: \\./\\[\\]]+$");
+  gvm_validator_add (validator, "web_application_urls",
+                     "^[-_@%[:alnum:],:\\./\\[\\]\\?&=#~+]+$");
   gvm_validator_add (validator, "optional_number", "^[0-9]*$");
   gvm_validator_add (validator, "oid", "^([0-9.]{1,80}|CVE-[-0-9]{1,14})$");
   gvm_validator_add (validator, "page", "^[_[:alnum:] ]+$");
@@ -700,6 +703,8 @@ gsad_init_validator ()
   gvm_validator_alias (validator, "hosts_filter", "filter");
   gvm_validator_alias (validator, "exclude_hosts", "hosts_opt");
   gvm_validator_alias (validator, "exclude_images", "image_references");
+  gvm_validator_alias (validator, "urls", "web_application_urls");
+  gvm_validator_alias (validator, "exclude_urls", "web_application_urls");
   gvm_validator_alias (validator, "in_assets", "boolean");
   gvm_validator_alias (validator, "in_use", "boolean");
   gvm_validator_alias (validator, "include_related", "number");

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -82,6 +82,7 @@ gsad_init_validator ()
                      "|(delete_ticket)"
                      "|(delete_tls_certificate)"
                      "|(delete_user)"
+                     "|(delete_web_application_target)"
                      "|(download_credential)"
                      "|(download_ssl_cert)"
                      "|(download_ca_pub)"

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -234,6 +234,8 @@ gsad_init_validator ()
                      "|(get_user)"
                      "|(get_users)"
                      "|(get_vulns)"
+                     "|(get_web_application_target)"
+                     "|(get_web_application_targets)"
                      "|(import_config)"
                      "|(import_port_list)"
                      "|(import_report_format)"
@@ -622,6 +624,7 @@ gsad_init_validator ()
   gvm_validator_alias (validator, "report_format_ids:value", "id");
   gvm_validator_alias (validator, "report_result_id", "id");
   gvm_validator_alias (validator, "report_uuid", "id");
+  gvm_validator_alias (validator, "web_application_target_id", "id");
 
   /* Define Optional IDs "^[a-z0-9\\-]*$" */
   gvm_validator_alias (validator, "credential_id", "optional_id");

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -135,6 +135,8 @@ gsad_init_validator ()
                      "|(export_tasks)"
                      "|(export_user)"
                      "|(export_users)"
+                     "|(export_web_application_target)"
+                     "|(export_web_application_targets)"
                      "|(get_agent_installer_instruction)"
                      "|(get_agent)"
                      "|(get_agents)"

--- a/src/gsad_validator_tests.c
+++ b/src/gsad_validator_tests.c
@@ -257,6 +257,55 @@ Ensure (gsad_validator, validate_language_type)
                is_equal_to (5));
 }
 
+Ensure (gsad_validator, validate_web_application_urls)
+{
+  validator_t validator = gsad_get_validator ();
+
+  assert_that (
+    gvm_validate (validator, "web_application_urls", "https://example.com"),
+    is_equal_to (0));
+  assert_that (
+    gvm_validate (validator, "web_application_urls", "http://localhost:8080"),
+    is_equal_to (0));
+  assert_that (gvm_validate (validator, "web_application_urls",
+                             "https://example.com/app?x=1&y=2"),
+               is_equal_to (0));
+  assert_that (gvm_validate (validator, "web_application_urls",
+                             "https://example.com,https://example.com/app"),
+               is_equal_to (0));
+  assert_that (gvm_validate (validator, "web_application_urls",
+                             "https://[0001:1:1:1::1]:8443/app"),
+               is_equal_to (0));
+
+  assert_that (gvm_validate (validator, "web_application_urls", ""),
+               is_equal_to (2));
+  assert_that (gvm_validate (validator, "web_application_urls",
+                             "https://example.com/<script>"),
+               is_equal_to (2));
+  assert_that (gvm_validate (validator, "web_application_urls",
+                             "https://example.com/with space"),
+               is_equal_to (2));
+  assert_that (gvm_validate (validator, "web_application_urls", NULL),
+               is_equal_to (5));
+}
+
+Ensure (gsad_validator, alias_web_application_target_fields)
+{
+  validator_t validator = gsad_get_validator ();
+
+  assert_that (gvm_validate (validator, "urls", "https://example.com"),
+               is_equal_to (0));
+  assert_that (
+    gvm_validate (validator, "exclude_urls", "https://example.com/logout"),
+    is_equal_to (0));
+  assert_that (gvm_validate (validator, "urls",
+                             "https://example.com,https://example.com/app"),
+               is_equal_to (0));
+
+  assert_that (gvm_validate (validator, "urls", "https://example.com/<script>"),
+               is_equal_to (2));
+}
+
 int
 main (int argc, char **argv)
 {
@@ -283,6 +332,9 @@ main (int argc, char **argv)
   add_test_with_context (suite, gsad_validator, alias_hosts_hosts_manual);
   add_test_with_context (suite, gsad_validator, alias_hostpath_scanner_host);
   add_test_with_context (suite, gsad_validator, validate_language_type);
+  add_test_with_context (suite, gsad_validator, validate_web_application_urls);
+  add_test_with_context (suite, gsad_validator,
+                         alias_web_application_target_fields);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

- Added GSAD support for web application targets.
- Added create, get, export, delete, trash, and save commands.
- Added validator support for web application target URLs.
- Tested the commands with `curl`/GSAD scripts.

## Why

- Web application targets need to be manageable from GSAD.
- This enables frontend/API flows for creating, viewing, exporting, deleting, restoring from trash, and updating web application targets.

## References

GEA-1823

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


