### PR TITLE
fix: allow Host Discovery IPv6 in alive test validation

### DIFF
--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -319,7 +319,7 @@ gsad_init_validator ()
   gvm_validator_add (
     validator, "alive_tests:value",
     "^(Scan Config Default|ICMP Ping|TCP-ACK Service Ping|TCP-SYN Service "
-    "Ping|ARP Ping|Consider Alive)$");
+    "Ping|ARP Ping|Consider Alive|Host Discovery IPv6)$");
   gvm_validator_add (validator, "apply_filter", "^(no|no_pagination|full)$");
   gvm_validator_add (validator, "asset_name", "(?s)^.*$");
   gvm_validator_add (validator, "asset_type", "^(host|os)$");


### PR DESCRIPTION
## What

- Add `Host Discovery IPv6` to the alive test validation so it can be accepted as a valid alive test.

## Why

- This is needed because `Host Discovery IPv6` is now supported for `openvasd`, and targets using this alive test should pass validation correctly.

## References

GEA-1727


