### PR TITLE
fix: pass report filters to get_report_closed_cves

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -10083,19 +10083,33 @@ get_report_closed_cves_gmp (gvm_connection_t *connection,
   GString *xml;
   entity_t entity;
   const char *report_id;
+  const char *filter;
+  const char *filter_id;
   gboolean details;
+  gboolean ignore_pagination;
   int ret;
 
   details = params_value_bool (params, "details");
+  ignore_pagination = params_value_bool (params, "ignore_pagination");
+
   report_id = params_value (params, "report_id");
+  filter = params_value (params, "filter");
+  filter_id = params_value (params, "filter_id");
 
   CHECK_VARIABLE_INVALID (report_id, "Get Report Closed CVEs");
+
+  if (filter == NULL || filter_id)
+    filter = "";
 
   ret = gvm_connection_sendf_xml (connection,
                                   "<get_report_closed_cves"
                                   " report_id=\"%s\""
-                                  " details=\"%d\"/>",
-                                  report_id, details);
+                                  " details=\"%d\""
+                                  " ignore_pagination=\"%d\""
+                                  " filter=\"%s\""
+                                  " filt_id=\"%s\"/>",
+                                  report_id, details, ignore_pagination, filter,
+                                  filter_id ? filter_id : FILT_ID_NONE);
 
   if (ret == -1)
     {


### PR DESCRIPTION
## What

Forward report filters, including the host filter, from GSA to the `get_report_closed_cves` GMP command.

Verified that the selected host filter is received by gvmd and applied to the closed CVE query.

## Why

The filter parameters were not forwarded, so closed CVEs were returned for all report hosts instead of only the filtered host.


## References

GEA-1681


