### PR TITLE
docs: fix 8 typos in code comments

### DIFF
--- a/src/gsad_command_response_data.c
+++ b/src/gsad_command_response_data.c
@@ -26,9 +26,9 @@ struct gsad_command_response_data
 };
 
 /**
- * @brief Initializes a gsad_commad_response_data_t struct.
+ * @brief Initializes a gsad_command_response_data_t struct.
  *
- * @param[in]  data  The gsad_commad_response_data_t struct to initialize
+ * @param[in]  data  The gsad_command_response_data_t struct to initialize
  */
 static void
 gsad_command_response_data_init (gsad_command_response_data_t *data)
@@ -42,7 +42,7 @@ gsad_command_response_data_init (gsad_command_response_data_t *data)
 }
 
 /**
- * @brief Allocates memory for a gsad_commad_response_data_t sturct and
+ * @brief Allocates memory for a gsad_command_response_data_t struct and
  * initializes it
  *
  * @return Pointer to the newly allocated gsad_command_response_data_t struct
@@ -57,12 +57,12 @@ gsad_command_response_data_new ()
 }
 
 /**
- * @brief Frees the memory of a gsad_commad_response_data_t struct
+ * @brief Frees the memory of a gsad_command_response_data_t struct
  *
  * If content_disposition of data is not NULL the content_disposition is also
  * being freed.
  *
- * @param[in] data The gsad_commad_response_data_t struct to free
+ * @param[in] data The gsad_command_response_data_t struct to free
  */
 void
 gsad_command_response_data_free (gsad_command_response_data_t *data)
@@ -78,7 +78,7 @@ gsad_command_response_data_free (gsad_command_response_data_t *data)
 }
 
 /**
- * @brief Set allow_caching flag of gsad_commad_response_data_t struct
+ * @brief Set allow_caching flag of gsad_command_response_data_t struct
  *
  * @param[in]  data           Command response data struct
  * @param[in]  allow_caching  allow_caching flag to set

--- a/src/gsad_http_handler.c
+++ b/src/gsad_http_handler.c
@@ -53,7 +53,7 @@ gsad_http_handler_set_leaf (gsad_http_handler_t *handler,
 {
   if (handler->next)
     {
-      // there are more handlers in the chaing, so we are not the leaf handler.
+      // there are more handlers in the chain, so we are not the leaf handler.
       // Set the leaf handler in the next handler in the chain.
       handler->next->set_leaf (handler->next, next, free_next);
     }

--- a/src/gsad_session.c
+++ b/src/gsad_session.c
@@ -267,7 +267,7 @@ gsad_session_replace_user_if_exists (gsad_user_t *user)
 }
 
 /**
- * @brief Removes all session of the user, except the one with the passed id.
+ * @brief Removes all sessions of the user, except the one with the passed id.
  *
  * @param[in] keep_id   ID of the session to keep
  * @param[in] username  The user to logout.


### PR DESCRIPTION
## Summary

Fix misspellings in Doxygen doc comments across 3 source files:

- `src/gsad_session.c`: "session" → "sessions" (missing plural)
- `src/gsad_http_handler.c`: "chaing" → "chain"
- `src/gsad_command_response_data.c`: "commad" → "command" (5 occurrences), "sturct" → "struct"

No functional changes — comments only.