### PR TITLE
add: add get_scan_report GMP command support in gsad

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -10827,6 +10827,99 @@ get_report_vulns_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Get a structured scan report and return the result.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Username and password for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data returned for the HTTP response.
+ *
+ * @return Structured scan report XML.
+ */
+char *
+get_scan_report_gmp (gvm_connection_t *connection,
+                     gsad_credentials_t *credentials, params_t *params,
+                     gsad_command_response_data_t *response_data)
+{
+  GString *xml;
+  entity_t entity;
+  const char *report_id;
+  const char *filter;
+  const char *filter_id;
+  int ret;
+
+  report_id = params_value (params, "report_id");
+  filter = params_value (params, "filter");
+  filter_id = params_value (params, "filter_id");
+
+  CHECK_VARIABLE_INVALID (report_id, "Get Scan Report");
+
+  if (filter == NULL || filter_id)
+    filter = "";
+
+  ret = gvm_connection_sendf_xml (connection,
+                                  "<get_scan_report"
+                                  " report_id=\"%s\""
+                                  " filter=\"%s\""
+                                  " filt_id=\"%s\"/>",
+                                  report_id, filter,
+                                  filter_id ? filter_id : FILT_ID_NONE);
+
+  if (ret == -1)
+    {
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the scan report. "
+        "The scan report could not be delivered. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
+
+  xml = g_string_new ("<get_scan_report>");
+
+  entity = NULL;
+  if (read_entity_and_string_c (connection, &entity, &xml))
+    {
+      g_string_free (xml, TRUE);
+
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the scan report. "
+        "The scan report could not be delivered. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
+
+  if (gmp_success (entity) != 1)
+    {
+      gchar *message;
+
+      set_http_status_from_entity (entity, response_data);
+
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
+
+      g_string_free (xml, TRUE);
+      free_entity (entity);
+
+      return message;
+    }
+
+  free_entity (entity);
+
+  g_string_append (xml, "</get_scan_report>");
+
+  return envelope_gmp (connection, credentials, params,
+                       g_string_free (xml, FALSE), response_data);
+}
+
+/**
  * @brief Run alert for a report.
  *
  * @param[in]  connection     Connection to manager.
@@ -21510,6 +21603,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_roles)
   ELSE (get_scanner)
   ELSE (get_scanners)
+  ELSE (get_scan_report)
   ELSE (get_schedule)
   ELSE (get_schedules)
   ELSE (get_setting)

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -102,21 +102,31 @@ get_report_cves_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
 char *
 get_report_errors_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                        gsad_command_response_data_t *);
+
 char *
 get_report_hosts_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                       gsad_command_response_data_t *);
+
 char *
 get_report_operating_systems_gmp (gvm_connection_t *, gsad_credentials_t *,
                                   params_t *, gsad_command_response_data_t *);
+
 char *
 get_report_ports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                       gsad_command_response_data_t *);
+
 char *
 get_report_tls_certificates_gmp (gvm_connection_t *, gsad_credentials_t *,
                                  params_t *, gsad_command_response_data_t *);
+
 char *
 get_report_vulns_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                       gsad_command_response_data_t *);
+
+char *
+get_scan_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
+                     gsad_command_response_data_t *);
+
 char *
 get_reports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                  gsad_command_response_data_t *);

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -199,6 +199,7 @@ gsad_init_validator ()
                      "|(get_roles)"
                      "|(get_scanner)"
                      "|(get_scanners)"
+                     "|(get_scan_report)"
                      "|(get_schedule)"
                      "|(get_schedules)"
                      "|(get_setting)"


### PR DESCRIPTION
## What

- Add GSAD support for the `get_scan_report` GMP command.
- Forward the report ID and filter parameters to gvmd.
- Return the structured scan report response to the client.

## Why

- GSAD needs to support the new `get_scan_report` command.
- This allows clients to retrieve a single structured scan report through GSAD.


## References

GEA-1948
depending on https://github.com/greenbone/gvmd/pull/3043


