### PR TITLE
fix: use scan_report_id for get_scan_report in gsad

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -10843,26 +10843,26 @@ get_scan_report_gmp (gvm_connection_t *connection,
 {
   GString *xml;
   entity_t entity;
-  const char *report_id;
+  const char *scan_report_id;
   const char *filter;
   const char *filter_id;
   int ret;
 
-  report_id = params_value (params, "report_id");
+  scan_report_id = params_value (params, "scan_report_id");
   filter = params_value (params, "filter");
   filter_id = params_value (params, "filter_id");
 
-  CHECK_VARIABLE_INVALID (report_id, "Get Scan Report");
+  CHECK_VARIABLE_INVALID (scan_report_id, "Get Scan Report");
 
   if (filter == NULL || filter_id)
     filter = "";
 
   ret = gvm_connection_sendf_xml (connection,
                                   "<get_scan_report"
-                                  " report_id=\"%s\""
+                                  " scan_report_id=\"%s\""
                                   " filter=\"%s\""
                                   " filt_id=\"%s\"/>",
-                                  report_id, filter,
+                                  scan_report_id, filter,
                                   filter_id ? filter_id : FILT_ID_NONE);
 
   if (ret == -1)

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -636,6 +636,7 @@ gsad_init_validator ()
   gvm_validator_alias (validator, "report_format_ids:value", "id");
   gvm_validator_alias (validator, "report_result_id", "id");
   gvm_validator_alias (validator, "report_uuid", "id");
+  gvm_validator_alias (validator, "scan_report_id", "id");
   gvm_validator_alias (validator, "web_application_target_id", "id");
 
   /* Define Optional IDs "^[a-z0-9\\-]*$" */


### PR DESCRIPTION
## What

- Update GSAD to use `scan_report_id` for the `get_scan_report` command.
- Align the GSAD request with the updated GMP command.

## Why

- To keep GSAD compatible with the latest `get_scan_report` GMP interface.
- To use the correct report ID attribute consistently.


## References

GEA-1948
depending on https://github.com/greenbone/gvmd/pull/3048


