### PR TITLE
Session Timeout

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -20019,9 +20019,8 @@ renew_session_gmp (gvm_connection_t *connection,
 
   if (user)
     {
-      gsad_user_session_renew_timeout (user);
-
-      message = g_strdup_printf ("%ld", gsad_user_session_get_timeout (user));
+      time_t session_duration = gsad_user_session_renew_timeout (user);
+      message = g_strdup_printf ("%ld", session_duration);
     }
   else
     {

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -21332,10 +21332,13 @@ login (gsad_http_connection_t *con, params_t *params,
           gsad_credentials_set_user (credentials, user);
           gsad_credentials_set_jwt (credentials, jwt);
 
-          // xml must not be NULL: gsad_http_create_envelope() expects a valid
-          // string and passing NULL would trigger a GLib critical
-          gchar *data = gsad_http_create_envelope (credentials, g_strdup (""),
-                                                   response_data);
+          // we just created the user so we can assume that the session duration
+          // is the max duration
+          time_t session_duration = gsad_user_session_get_max_duration ();
+          gchar *message =
+            g_strdup_printf ("<duration>%ld</duration>", session_duration);
+          gchar *data =
+            gsad_http_create_envelope (credentials, message, response_data);
 
           ret = gsad_http_create_response (con, data, response_data,
                                            gsad_user_get_cookie (user));

--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -21851,12 +21851,6 @@ exec_gmp_post (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
       return gsad_http_create_response (con, res, response_data, NULL);
     }
 
-  /* always renew session for http post */
-  if (user)
-    {
-      gsad_user_session_renew_timeout (user);
-    }
-
   /* Handle the usual commands. */
   if (0)
     {

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -995,17 +995,14 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
       const gchar *locale = gsad_user_get_language (user);
       const gchar *client_address = gsad_user_get_client_address (user);
       const gchar *token = gsad_user_get_token (user);
-      time_t timeout = gsad_user_session_get_timeout (user);
-
       xml_string_append (string,
                          "<client_address>%s</client_address>"
                          "<i18n>%s</i18n>"
-                         "<session>%ld</session>"
                          "<timezone>%s</timezone>"
                          "<token>%s</token>",
                          client_address ? client_address : "",
-                         locale ? locale : "", timeout,
-                         timezone ? timezone : "", token ? token : "");
+                         locale ? locale : "", timezone ? timezone : "",
+                         token ? token : "");
     }
 
   if (jwt)

--- a/src/gsad_http.c
+++ b/src/gsad_http.c
@@ -995,7 +995,7 @@ gsad_http_create_envelope (gsad_credentials_t *credentials, gchar *xml,
       const gchar *locale = gsad_user_get_language (user);
       const gchar *client_address = gsad_user_get_client_address (user);
       const gchar *token = gsad_user_get_token (user);
-      int timeout = gsad_user_session_get_timeout (user);
+      time_t timeout = gsad_user_session_get_timeout (user);
 
       xml_string_append (string,
                          "<client_address>%s</client_address>"

--- a/src/gsad_user.c
+++ b/src/gsad_user.c
@@ -22,6 +22,12 @@
 #include <gvm/util/uuidutils.h> /* for gvm_uuid_make */
 #include <string.h>             /* for strcmp */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "gsad user"
+
 /**
  * @brief Create a new user
  *
@@ -72,6 +78,10 @@ gsad_user_new_with_data (const gchar *username, const gchar *password,
   user->time = time (NULL);
 
   gsad_user_set_language (user, language);
+
+  g_debug (
+    "Created new user %s with timezone %s, address %s and login time %ld",
+    username, user->timezone, user->address, user->time);
 
   return user;
 }
@@ -361,4 +371,5 @@ void
 gsad_user_renew_time (gsad_user_t *user)
 {
   user->time = time (NULL);
+  g_debug ("Renewed login time for user %s to %ld", user->username, user->time);
 }

--- a/src/gsad_user_session.c
+++ b/src/gsad_user_session.c
@@ -153,6 +153,19 @@ gsad_user_session_find (const gchar *cookie, const gchar *token,
 }
 
 /**
+ * @brief Get the maximum session duration in seconds
+ *
+ * @return The maximum session duration in seconds, based on the global
+ * settings.
+ */
+const time_t
+gsad_user_session_get_max_duration (void)
+{
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  return gsad_settings_get_session_timeout (gsad_global_settings) * 60;
+}
+
+/**
  * @brief Get the session timeout time of a user
  *
  * @param[in] user User whose session timeout time is to be retrieved.
@@ -162,9 +175,7 @@ gsad_user_session_find (const gchar *cookie, const gchar *token,
 const time_t
 gsad_user_session_get_timeout (gsad_user_t *user)
 {
-  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
-  return user->time
-         + (gsad_settings_get_session_timeout (gsad_global_settings) * 60);
+  return user->time + gsad_user_session_get_max_duration ();
 }
 
 /**
@@ -174,14 +185,17 @@ gsad_user_session_get_timeout (gsad_user_t *user)
  *
  * This function should be called when the session timeout of a user needs to be
  * extended.
+ *
+ * @return The session duration in seconds.
  */
-void
+time_t
 gsad_user_session_renew_timeout (gsad_user_t *user)
 {
   if (!user)
     {
-      return;
+      return 0;
     }
   gsad_user_renew_time (user);
   gsad_session_replace_user_if_exists (user);
+  return gsad_user_session_get_max_duration ();
 }

--- a/src/gsad_user_session.c
+++ b/src/gsad_user_session.c
@@ -166,19 +166,6 @@ gsad_user_session_get_max_duration (void)
 }
 
 /**
- * @brief Get the session timeout time of a user
- *
- * @param[in] user User whose session timeout time is to be retrieved.
- *
- * @return The session timeout time of the user, calculated as the login time
- */
-const time_t
-gsad_user_session_get_timeout (gsad_user_t *user)
-{
-  return user->time + gsad_user_session_get_max_duration ();
-}
-
-/**
  * @brief Renew the session timeout of a user by updating the login time to the
  * current time and replacing the user in the session store with the updated
  * user.

--- a/src/gsad_user_session.h
+++ b/src/gsad_user_session.h
@@ -26,7 +26,10 @@ gsad_user_session_is_expired (gsad_user_t *user);
 const time_t
 gsad_user_session_get_timeout (gsad_user_t *user);
 
-void
+const time_t
+gsad_user_session_get_max_duration (void);
+
+time_t
 gsad_user_session_renew_timeout (gsad_user_t *user);
 
 #endif /* _GSAD_USER_SESSION_H */

--- a/src/gsad_user_session.h
+++ b/src/gsad_user_session.h
@@ -24,9 +24,6 @@ gboolean
 gsad_user_session_is_expired (gsad_user_t *user);
 
 const time_t
-gsad_user_session_get_timeout (gsad_user_t *user);
-
-const time_t
 gsad_user_session_get_max_duration (void);
 
 time_t

--- a/src/gsad_user_session_tests.c
+++ b/src/gsad_user_session_tests.c
@@ -142,21 +142,6 @@ Ensure (gsad_user_session, should_check_session_expiration)
   gsad_user_free (user);
 }
 
-Ensure (gsad_user_session, should_allow_to_get_the_timeout)
-{
-  int timeout_in_minutes = 10;
-  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
-  gsad_settings_set_session_timeout (gsad_global_settings, timeout_in_minutes);
-  gsad_user_t *user =
-    gsad_user_new_with_data ("username1", "password1", "timezone1",
-                             "capabilities1", "language1", "address1", "jwt1");
-  user->time = 0;
-  assert_equal (gsad_user_get_time (user), 0);
-  assert_equal (gsad_user_session_get_timeout (user), timeout_in_minutes * 60);
-
-  gsad_user_free (user);
-}
-
 Ensure (gsad_user_session,
         should_return_bad_missing_token_for_user_find_without_token)
 {
@@ -372,8 +357,6 @@ main (int argc, char **argv)
                          should_remove_expired_sessions);
   add_test_with_context (suite, gsad_user_session,
                          should_check_session_expiration);
-  add_test_with_context (suite, gsad_user_session,
-                         should_allow_to_get_the_timeout);
   add_test_with_context (
     suite, gsad_user_session,
     should_return_bad_missing_token_for_user_find_without_token);

--- a/src/gsad_user_session_tests.c
+++ b/src/gsad_user_session_tests.c
@@ -352,6 +352,13 @@ Ensure (gsad_user_session, should_allow_to_renew_timeout)
   gsad_user_free (user);
 }
 
+Ensure (gsad_user_session, should_allow_to_get_max_duration)
+{
+  gsad_settings_t *gsad_global_settings = gsad_settings_get_global_settings ();
+  gsad_settings_set_session_timeout (gsad_global_settings, 10);
+  assert_that (gsad_user_session_get_max_duration (), is_equal_to (600));
+}
+
 int
 main (int argc, char **argv)
 {
@@ -393,6 +400,8 @@ main (int argc, char **argv)
                          should_allow_to_renew_timeout_with_null_user);
   add_test_with_context (suite, gsad_user_session,
                          should_allow_to_renew_timeout);
+  add_test_with_context (suite, gsad_user_session,
+                         should_allow_to_get_max_duration);
 
   int ret = run_test_suite (suite, create_text_reporter ());
   destroy_test_suite (suite);


### PR DESCRIPTION
## What

Refactor session timeout handling

* Return session duration in seconds from `login` and `renew_session` responses
* Drop `<timeout>` from the `<envelope>` of every response
* Don't extend the user session for GMP POST requests automatically

**THIS CHANGE BREAKS EXISTING GSA VERSIONS**

## Why

Making the session timeout handling independent of the system time to avoid issues in GSA. When the system time of the machine running gsad and the system time of the user running GSA are not in sync a wrong session timeout is displayed. The session still works correctly but the user gets a wrong impression. By using a session duration in seconds instead of the end time of the session this issue can be avoided.

## References

https://jira.greenbone.net/browse/GEA-1743
https://github.com/greenbone/gsa/pull/5446

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


