### PR TITLE
add: add get_audit_report GMP command support in gsad

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -10920,6 +10920,99 @@ get_scan_report_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Get a structured audit report and return the result.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Username and password for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data returned for the HTTP response.
+ *
+ * @return Structured audit report XML.
+ */
+char *
+get_audit_report_gmp (gvm_connection_t *connection,
+                      gsad_credentials_t *credentials, params_t *params,
+                      gsad_command_response_data_t *response_data)
+{
+  GString *xml;
+  entity_t entity;
+  const char *audit_report_id;
+  const char *filter;
+  const char *filter_id;
+  int ret;
+
+  audit_report_id = params_value (params, "audit_report_id");
+  filter = params_value (params, "filter");
+  filter_id = params_value (params, "filter_id");
+
+  CHECK_VARIABLE_INVALID (audit_report_id, "Get Audit Report");
+
+  if (filter == NULL || filter_id)
+    filter = "";
+
+  ret = gvm_connection_sendf_xml (connection,
+                                  "<get_audit_report"
+                                  " audit_report_id=\"%s\""
+                                  " filter=\"%s\""
+                                  " filt_id=\"%s\"/>",
+                                  audit_report_id, filter,
+                                  filter_id ? filter_id : FILT_ID_NONE);
+
+  if (ret == -1)
+    {
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the audit report. "
+        "The audit report could not be delivered. "
+        "Diagnostics: Failure to send command to manager daemon.",
+        response_data);
+    }
+
+  xml = g_string_new ("<get_audit_report>");
+
+  entity = NULL;
+  if (read_entity_and_string_c (connection, &entity, &xml))
+    {
+      g_string_free (xml, TRUE);
+
+      gsad_command_response_data_set_status_code (
+        response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
+
+      return gsad_http_create_gsad_message (
+        credentials,
+        "An internal error occurred while getting the audit report. "
+        "The audit report could not be delivered. "
+        "Diagnostics: Failure to receive response from manager daemon.",
+        response_data);
+    }
+
+  if (gmp_success (entity) != 1)
+    {
+      gchar *message;
+
+      set_http_status_from_entity (entity, response_data);
+
+      message = gsad_http_create_gsad_message (
+        credentials, entity_attribute (entity, "status_text"), response_data);
+
+      g_string_free (xml, TRUE);
+      free_entity (entity);
+
+      return message;
+    }
+
+  free_entity (entity);
+
+  g_string_append (xml, "</get_audit_report>");
+
+  return envelope_gmp (connection, credentials, params,
+                       g_string_free (xml, FALSE), response_data);
+}
+
+/**
  * @brief Run alert for a report.
  *
  * @param[in]  connection     Connection to manager.
@@ -21553,6 +21646,7 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_agent_groups)
   ELSE (get_asset)
   ELSE (get_assets)
+  ELSE (get_audit_report)
   ELSE (get_aggregate)
   ELSE (get_alert)
   ELSE (get_alerts)

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -128,6 +128,10 @@ get_scan_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                      gsad_command_response_data_t *);
 
 char *
+get_audit_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
+                      gsad_command_response_data_t *);
+
+char *
 get_reports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                  gsad_command_response_data_t *);
 

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -150,6 +150,7 @@ gsad_init_validator ()
                      "|(get_alerts)"
                      "|(get_asset)"
                      "|(get_assets)"
+                     "|(get_audit_report)"
                      "|(get_capabilities)"
                      "|(get_config)"
                      "|(get_config_family)"
@@ -595,6 +596,7 @@ gsad_init_validator ()
   gvm_validator_alias (validator, "agent_uuid", "id");
   gvm_validator_alias (validator, "alert_id_2", "alert_id");
   gvm_validator_alias (validator, "alert_id", "id");
+  gvm_validator_alias (validator, "audit_report_id", "id");
   gvm_validator_alias (validator, "config_id", "id");
   gvm_validator_alias (validator, "cve_scanner_id", "id");
   gvm_validator_alias (validator, "delta_report_id", "id");


### PR DESCRIPTION
## What

- Add GSAD support for the `get_audit_report` GMP command.
- Return the structured scan report response to the client.

## Why

- GSAD needs to support the new `get_audit_report` command.
- This allows clients to retrieve a single structured audit report through GSAD.


## References

GEA-1961

depending on https://github.com/greenbone/gvmd/pull/3062


