### PR TITLE
Update dependabot config and pin actions to commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+    ignore:
+      - dependency-name: "greenbone/actions"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    commit-message:
+      prefix: "Deps"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   changelog:
     name: Show changelog since last release
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check C Source Code Formatting
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check Source Format
         run: |
           clang-format -i -style=file src/*.{c,h}
@@ -30,7 +30,7 @@ jobs:
           - testing
     container: ghcr.io/greenbone/gvm-libs:${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Configure and compile gsad
@@ -48,7 +48,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --no-install-recommends -y ca-certificates git libcgreen1-dev
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Configure and compile gsad
@@ -68,7 +68,7 @@ jobs:
     name: Check CMake Formatting
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: greenbone/actions/uv@v3
         with:
           install: gersemi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: C
+          build-mode: manual
         # build between init and analyze ...
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
@@ -41,4 +42,4 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Debug ..
           make install
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           release-type-input: ${{ inputs.release-type }}
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false


### PR DESCRIPTION


## What
Update dependabot config and pin actions to commits

## Why

Only update greenbone actions for major updates because we trust these tags and don't want to get PRs for each bugfix or minor releases.

Also group updates for github's native actions in one PR to allow for less required reviews.

Pin actions to commits for improved security. Git tags can be overridden easily. Hashes not.