### PR TITLE
add: add get_report_exports GMP command support in gsad

### DIFF
--- a/src/gsad_gmp.c
+++ b/src/gsad_gmp.c
@@ -11227,6 +11227,44 @@ export_scan_report_gmp (gvm_connection_t *connection,
 }
 
 /**
+ * @brief Get report exports.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Credentials for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_report_exports_gmp (gvm_connection_t *connection,
+                        gsad_credentials_t *credentials, params_t *params,
+                        gsad_command_response_data_t *response_data)
+{
+  return get_many (connection, "report_exports", credentials, params, NULL,
+                   response_data);
+}
+
+/**
+ * @brief Get a report export.
+ *
+ * @param[in]  connection      Connection to manager.
+ * @param[in]  credentials     Credentials for authentication.
+ * @param[in]  params          Request parameters.
+ * @param[out] response_data   Extra data for the HTTP response.
+ *
+ * @return Enveloped XML object.
+ */
+char *
+get_report_export_gmp (gvm_connection_t *connection,
+                       gsad_credentials_t *credentials, params_t *params,
+                       gsad_command_response_data_t *response_data)
+{
+  return get_one (connection, "report_export", credentials, params, NULL, NULL,
+                  response_data);
+}
+
+/**
  * @brief Run alert for a report.
  *
  * @param[in]  connection     Connection to manager.
@@ -21905,6 +21943,8 @@ exec_gmp_get (gsad_http_connection_t *con, gsad_connection_info_t *con_info,
   ELSE (get_reports)
   ELSE (get_report_config)
   ELSE (get_report_configs)
+  ELSE (get_report_export)
+  ELSE (get_report_exports)
   ELSE (get_report_format)
   ELSE (get_report_formats)
   ELSE (get_resource_names)

--- a/src/gsad_gmp.h
+++ b/src/gsad_gmp.h
@@ -140,6 +140,14 @@ export_scan_report_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                         gsad_command_response_data_t *);
 
 char *
+get_report_exports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
+                        gsad_command_response_data_t *);
+
+char *
+get_report_export_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
+                       gsad_command_response_data_t *);
+
+char *
 get_reports_gmp (gvm_connection_t *, gsad_credentials_t *, params_t *,
                  gsad_command_response_data_t *);
 

--- a/src/gsad_validator.c
+++ b/src/gsad_validator.c
@@ -193,6 +193,8 @@ gsad_init_validator ()
                      "|(get_reports)"
                      "|(get_report_config)"
                      "|(get_report_configs)"
+                     "|(get_report_export)"
+                     "|(get_report_exports)"
                      "|(get_report_format)"
                      "|(get_report_formats)"
                      "|(get_resource_names)"
@@ -620,6 +622,7 @@ gsad_init_validator ()
   gvm_validator_alias (validator, "report_config_id", "id");
   gvm_validator_alias (validator, "report_format_id", "id");
   gvm_validator_alias (validator, "report_id", "id");
+  gvm_validator_alias (validator, "report_export_id", "id");
   gvm_validator_alias (validator, "result_id", "id");
   gvm_validator_alias (validator, "role_id", "id");
   gvm_validator_alias (validator, "scanner_id", "id");


### PR DESCRIPTION
## What

- Add GSAD support for the `get_report_exports` GMP command.
- Return the  report export response to the client.

## Why

- GSAD needs to support the new `get_report_exports` command.


## References

GEA-2041
depending on https://github.com/greenbone/gvmd/pull/3113